### PR TITLE
Add Rust benchmarking suite (Criterion) and documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +370,7 @@ dependencies = [
  "blake3",
  "bs58",
  "bytes",
+ "criterion",
  "dirs",
  "ed25519-dalek",
  "fastcdc",
@@ -536,6 +543,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +582,33 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -719,6 +759,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +818,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1227,6 +1309,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy 0.8.37",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1374,10 +1467,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1770,6 +1883,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2048,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polling"
@@ -2101,7 +2248,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -2121,7 +2268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -2768,6 +2915,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,6 +3258,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -48,8 +48,13 @@ default = []
 fuse = ["fuser"]
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1"
 tempfile = "3"
+
+[[bench]]
+name = "performance"
+harness = false
 
 [build-dependencies]
 prost-build = "0.12"

--- a/base/benches/performance.rs
+++ b/base/benches/performance.rs
@@ -1,0 +1,165 @@
+use base::{
+    chunk_data, compute_hash, compute_merkle_root, ChunkManifest, ChunkRef, LatticeRepo, Object,
+    ObjectType,
+};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn temp_repo_root() -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("create tempdir");
+    let root = dir.path().join("repo");
+    (dir, root)
+}
+
+fn benchmark_chunking(c: &mut Criterion) {
+    let mut group = c.benchmark_group("chunking");
+    let data = vec![0u8; 16 * 1024 * 1024];
+
+    group.bench_function("chunk_data_16mb", |b| {
+        b.iter(|| {
+            let _ = chunk_data(&data);
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_hashing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hashing");
+    let data = vec![0u8; 16 * 1024 * 1024];
+
+    group.bench_function("compute_hash_16mb", |b| {
+        b.iter(|| {
+            let _ = compute_hash(&data);
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_merkle(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merkle");
+    let data = vec![0u8; 16 * 1024 * 1024];
+    let boundaries = chunk_data(&data);
+    let hashes: Vec<_> = boundaries
+        .iter()
+        .map(|chunk| compute_hash(&data[chunk.offset..chunk.offset + chunk.length]))
+        .collect();
+
+    group.bench_function("compute_merkle_root_16mb", |b| {
+        b.iter(|| {
+            let _ = compute_merkle_root(&hashes);
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_repo_store_and_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("repo");
+    let data = vec![1u8; 8 * 1024 * 1024];
+
+    group.bench_function("repo_store_object_8mb", |b| {
+        b.iter_batched(
+            || {
+                let (_dir, root) = temp_repo_root();
+                let repo = LatticeRepo::open_at(&root).expect("open repo");
+                (repo, _dir)
+            },
+            |(repo, _dir)| {
+                let runtime = tokio::runtime::Runtime::new().expect("runtime");
+                runtime.block_on(async {
+                    let _ = repo.store_object_data(&data).await.expect("store object");
+                });
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("repo_read_object_8mb", |b| {
+        b.iter_batched(
+            || {
+                let (_dir, root) = temp_repo_root();
+                let repo = LatticeRepo::open_at(&root).expect("open repo");
+                let runtime = tokio::runtime::Runtime::new().expect("runtime");
+                let manifest = runtime
+                    .block_on(async { repo.store_object_data(&data).await })
+                    .expect("manifest");
+                (repo, manifest, _dir)
+            },
+            |(repo, manifest, _dir)| {
+                let runtime = tokio::runtime::Runtime::new().expect("runtime");
+                runtime.block_on(async {
+                    let _ = repo.read_object_data(&manifest).await.expect("read object");
+                });
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn benchmark_metadata_store(c: &mut Criterion) {
+    let mut group = c.benchmark_group("metadata");
+
+    group.bench_function("store_load_object", |b| {
+        b.iter_batched(
+            || {
+                let (_dir, root) = temp_repo_root();
+                let repo = LatticeRepo::open_at(&root).expect("open repo");
+                let object = Object::new(ObjectType::Blob, Default::default(), [0u8; 32]);
+                (repo, object, _dir)
+            },
+            |(repo, object, _dir)| {
+                repo.metadata.store_object(&object).expect("store object");
+                let _ = repo.metadata.load_object(&object.id).expect("load object");
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn benchmark_manifest_serialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("manifest");
+    let data = vec![0u8; 8 * 1024 * 1024];
+    let boundaries = chunk_data(&data);
+    let chunks: Vec<ChunkRef> = boundaries
+        .iter()
+        .map(|chunk| ChunkRef {
+            hash: compute_hash(&data[chunk.offset..chunk.offset + chunk.length]),
+            offset: chunk.offset as u64,
+            length: chunk.length as u32,
+        })
+        .collect();
+    let manifest = ChunkManifest {
+        version: 1,
+        total_size: data.len() as u64,
+        chunk_size_avg: 16 * 1024,
+        chunks,
+        merkle_root: compute_hash(b"root"),
+    };
+
+    group.bench_function("manifest_encode_decode", |b| {
+        b.iter(|| {
+            let encoded = bincode::serialize(&manifest).expect("serialize");
+            let _: ChunkManifest = bincode::deserialize(&encoded).expect("deserialize");
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_chunking,
+    benchmark_hashing,
+    benchmark_merkle,
+    benchmark_repo_store_and_read,
+    benchmark_metadata_store,
+    benchmark_manifest_serialization
+);
+criterion_main!(benches);

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,81 @@
+# Benchmarking (Rust)
+
+## Scope
+This document covers Rust-side performance for the LatticeFS core (`base`) library, with a focus on
+chunking, hashing, metadata, and repository read/write paths. Go services are out of scope for now.
+
+## Benchmark suite overview
+The suite is implemented as Criterion benchmarks under `base/benches/performance.rs`. It targets:
+
+- **Chunking**: FastCDC boundary detection on 16 MiB buffers.
+- **Hashing**: BLAKE3 hash on 16 MiB buffers.
+- **Merkle root**: Merkle root calculation over chunk hashes from a 16 MiB buffer.
+- **Repo store**: `LatticeRepo::store_object_data` on 8 MiB buffers (includes chunking + write).
+- **Repo read**: `LatticeRepo::read_object_data` on 8 MiB buffers (chunk reassembly + read).
+- **Metadata**: Store + load a single object in sled (metadata tree).
+- **Manifest**: Serialize + deserialize `ChunkManifest` using `bincode`.
+
+### How to run
+```bash
+cargo bench -p base --bench performance
+```
+
+Criterion reports are written to `target/criterion/` (including HTML charts).
+
+## Environment used for the numbers below
+- CPU: Intel(R) Xeon(R) Platinum 8370C @ 2.80GHz (3 vCPUs) (KVM) — `lscpu`.
+- Rust: `rustc 1.89.0 (29483883e 2025-08-04)`.
+
+## Results (Criterion, 100 samples)
+Times are reported as `[low, median, high]` from Criterion’s analysis.
+
+| Benchmark | Median time | Notes |
+| --- | --- | --- |
+| `chunking/chunk_data_16mb` | **14.700 ms** | 2% outliers (mild). |
+| `hashing/compute_hash_16mb` | **6.8127 ms** | 10% outliers (mild/severe). |
+| `merkle/compute_merkle_root_16mb` | **18.969 µs** | 6% outliers. |
+| `repo/repo_store_object_8mb` | **18.574 ms** | 12% outliers (mild/severe). |
+| `repo/repo_read_object_8mb` | **12.255 ms** | 14% outliers (mild/severe). |
+| `metadata/store_load_object` | **2.7328 ms** | 14% outliers (mild/severe). |
+| `manifest/manifest_encode_decode` | **26.812 µs** | 5% outliers. |
+
+## Evaluation & opinions
+### Observations
+1. **Chunking + hashing are the dominant per-object CPU costs**, as expected. The 16 MiB chunking pass
+   is ~2.2x the hash pass; both are large relative to metadata or Merkle costs.
+2. **Repo store/read are primarily I/O + chunking**. The 8 MiB store time is in the high teens of ms,
+   which roughly scales with chunking + write overhead. Reads show wider variance (higher outliers),
+   suggesting filesystem/cache effects dominate.
+3. **Merkle root calculation is negligible** compared to chunking/hash (tens of microseconds).
+4. **Metadata store/load is slower than expected for a single object** (median ~2.7 ms), which likely
+   reflects sled’s transaction overhead and filesystem sync behavior in short-lived DBs.
+5. **Manifest serialization is small** and not a significant bottleneck for the tested size.
+
+### What this means for end-user commands
+Most CLI commands that ingest or export data will be dominated by:
+- **FastCDC chunking** (CPU-bound).
+- **BLAKE3 hashing** (CPU-bound).
+- **Chunk I/O** to the content store (I/O-bound).
+
+Metadata-heavy commands (tagging, small-object churn, or queries) may experience noticeable cost if
+they perform frequent sled writes/reads.
+
+## Improvement opportunities (priority × complexity)
+> Priority: **P0** (must), **P1** (should), **P2** (nice-to-have).  
+> Complexity: **S** (small), **M** (medium), **L** (large).
+
+| Area | Why it matters (benchmark reference) | Priority | Complexity |
+| --- | --- | --- | --- |
+| **Parallelize chunking + hashing** | `chunk_data_16mb` + `compute_hash_16mb` dominate CPU time. Parallelizing per-chunk hashing (and possibly chunk boundary detection) would reduce wall time on multi-core systems. | P0 | M |
+| **Batch metadata writes** | `metadata/store_load_object` shows ms-level overhead per object. Grouping metadata ops in batched transactions or caching hot objects can reduce repeated writes. | P0 | M |
+| **Reuse a persistent tokio runtime in benchmarks & hot paths** | Repo benchmarks currently create a runtime per iteration; real code also spawns runtimes in CLI. Pooling/long-lived runtime reduces overhead. | P1 | M |
+| **Improve chunk store I/O (fsync strategy, write buffering)** | `repo_store_object_8mb` cost implies I/O sensitivity. Consider write buffering or optional fsync in non-critical paths. | P1 | L |
+| **Tune FastCDC parameters per file size** | Chunking cost is high; dynamic min/avg/max sizing for small files may reduce CPU for small/medium objects. | P1 | M |
+| **Evaluate `sled` configuration** | Metadata costs could be improved by adjusting `cache_capacity`, `flush_every_ms`, or migrating hot paths to in-memory caches. | P1 | M |
+| **Checksum/manifest caching** | Reusing computed hashes/manifests across operations would reduce recomputation. | P2 | M |
+| **I/O parallelism on read** | `repo_read_object_8mb` variance suggests single-threaded reads; parallel reassembly and read-ahead could help. | P2 | L |
+
+## Next steps
+1. Expand the suite with CLI-level benchmarks (import/export, query, tag operations).
+2. Add profile-guided optimization (PPROF or `perf`) alongside Criterion for CPU flame graphs.
+3. Track benchmarks in CI (with a baseline) once stable workloads are defined.

--- a/docs/benchmarking_improvements.md
+++ b/docs/benchmarking_improvements.md
@@ -1,0 +1,78 @@
+# Benchmark-driven improvement plan (Rust)
+
+This document proposes concrete performance improvements tied directly to the benchmark results
+in `docs/benchmarking.md`. Each item describes the likely impact, the target benchmarks, and a
+rough implementation approach.
+
+## P0 — High priority
+
+### 1) Parallel chunk hashing and Merkle construction
+**Targets:** `chunking/chunk_data_16mb`, `hashing/compute_hash_16mb`, `repo/repo_store_object_8mb`  
+**Why:** Chunking + hashing dominate CPU time. Parallelism should reduce wall-clock time on multi-core
+systems (especially for large objects).
+
+**Approach (rough):**
+- When chunk boundaries are known, hash each chunk in parallel using rayon or tokio blocking tasks.
+- Build Merkle roots in a parallel reduction (pairwise hashes per level).
+- Ensure chunk ordering is preserved for deterministic manifests.
+
+### 2) Batch metadata operations
+**Targets:** `metadata/store_load_object`  
+**Why:** Single-object round trips take milliseconds. Batching can reduce per-object overhead, especially
+for imports or tag updates across many objects.
+
+**Approach (rough):**
+- Wrap multiple `store_*` calls in a single sled transaction.
+- Add a metadata write queue with periodic flush.
+- Introduce a small LRU cache for hot objects/versions to reduce load calls.
+
+## P1 — Medium priority
+
+### 3) Long-lived tokio runtime for CLI + benchmarks
+**Targets:** `repo/repo_store_object_8mb`, `repo/repo_read_object_8mb`  
+**Why:** Runtime creation is expensive and can inflate small/medium workloads.
+
+**Approach (rough):**
+- Construct a single `Runtime` in CLI main and pass it to command handlers or use `tokio::main` for
+  full async execution.
+- For benchmarks, keep a runtime per benchmark group rather than per iteration.
+
+### 4) Chunk store write buffering and fsync control
+**Targets:** `repo/repo_store_object_8mb`  
+**Why:** I/O overhead can dominate storage operations.
+
+**Approach (rough):**
+- Add an opt-in buffered writer for chunk storage.
+- Allow configurable fsync behavior (always / periodic / never in dev).
+- Batch filesystem directory creation for chunk paths.
+
+### 5) Adaptive FastCDC parameters for small files
+**Targets:** `chunking/chunk_data_16mb` (and new small-file benchmarks)  
+**Why:** Small files pay a similar chunking overhead despite smaller size.
+
+**Approach (rough):**
+- For files under a threshold, use larger minimum chunks or fall back to a single chunk path.
+- Keep protocol compatibility by storing chosen chunking params in the manifest.
+
+## P2 — Lower priority
+
+### 6) Read-side parallelism and read-ahead
+**Targets:** `repo/repo_read_object_8mb`  
+**Why:** Read variance suggests I/O effects; parallelizing chunk reads could stabilize latency.
+
+**Approach (rough):**
+- Read chunks concurrently with a bounded task queue.
+- Implement read-ahead for sequential access patterns.
+
+### 7) Manifest + hash caching
+**Targets:** `manifest/manifest_encode_decode`, `repo/repo_store_object_8mb`  
+**Why:** Recomputing manifests and hashes across repeated operations is avoidable.
+
+**Approach (rough):**
+- Cache recent manifests keyed by object id + version id.
+- Add a small in-memory hash cache when chunking in tight loops.
+
+## Suggested follow-up benchmarks
+1. CLI import/export benchmarks on a fixed dataset.
+2. Metadata-heavy workloads (tagging, policy updates, queries).
+3. Read amplification tests (many small chunks vs. few large chunks).


### PR DESCRIPTION
### Motivation
- Provide a focused benchmarking suite for the Rust core (`base`) to measure chunking, hashing, metadata, and repo I/O performance and locate bottlenecks. 
- Ship actionable documentation and a prioritized improvement plan tied to measured results so maintainers know where to optimize next.

### Description
- Add Criterion as a development benchmark dependency and an explicit bench target in `base/Cargo.toml` via `criterion = { version = "0.5", features = ["html_reports"] }` and `[[bench]] name = "performance"`.
- Add `base/benches/performance.rs` with Criterion benchmarks for: `chunk_data` (FastCDC chunking), `compute_hash` (BLAKE3 hashing), `compute_merkle_root`, `LatticeRepo::store_object_data` and `read_object_data` (repo store/read), metadata `store`/`load` using sled, and `ChunkManifest` encode/decode via `bincode`.
- Add documentation `docs/benchmarking.md` that describes the suite, how to run it (`cargo bench -p base --bench performance`), the environment used, and the measured median times for each benchmark.
- Add `docs/benchmarking_improvements.md` containing a benchmark-driven, prioritized improvement plan (parallel hashing, batched metadata ops, runtime reuse, I/O buffering, adaptive FastCDC tuning, read-side parallelism, caching).

### Testing
- Ran the benchmark suite with `cargo bench -p base --bench performance`, which completed successfully and produced Criterion reports under `target/criterion/` (HTML charts available). 
- Environment used for the run: CPU: Intel(R) Xeon(R) Platinum 8370C @ 2.80GHz (3 vCPUs) (`lscpu`), Rust: `rustc 1.89.0`.
- Key median results reported by Criterion (100 samples): `chunking/chunk_data_16mb` — 14.700 ms; `hashing/compute_hash_16mb` — 6.8127 ms; `merkle/compute_merkle_root_16mb` — 18.969 µs; `repo/repo_store_object_8mb` — 18.574 ms; `repo/repo_read_object_8mb` — 12.255 ms; `metadata/store_load_object` — 2.7328 ms; `manifest/manifest_encode_decode` — 26.812 µs; all benchmarks ran to completion (some warnings about unused imports only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698339d126cc8321b84fe18915cf6680)