### PR TITLE
feat(ipc): Add verbose logging and enhance shares output

### DIFF
--- a/base/src/config.rs
+++ b/base/src/config.rs
@@ -17,6 +17,7 @@ pub struct Config {
     pub share: ShareConfig,
     pub import: ImportConfig,
     pub logging: LoggingConfig,
+    pub ipc: IpcConfig,
 }
 
 impl Default for Config {
@@ -29,6 +30,7 @@ impl Default for Config {
             share: ShareConfig::default(),
             import: ImportConfig::default(),
             logging: LoggingConfig::default(),
+            ipc: IpcConfig::default(),
         }
     }
 }
@@ -157,6 +159,20 @@ impl Default for LoggingConfig {
             level: "info".to_string(),
             format: "json".to_string(),
             audit_log: "~/.latticefs/logs/events.jsonl".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct IpcConfig {
+    pub verbose: bool,
+}
+
+impl Default for IpcConfig {
+    fn default() -> Self {
+        Self {
+            verbose: false,
         }
     }
 }

--- a/base/src/ipc/server.rs
+++ b/base/src/ipc/server.rs
@@ -1,7 +1,7 @@
 use crate::crypto::{Capability, Facts, Permission, PublicKey};
 use crate::error::{LatticeError, Result};
 use crate::events::Event;
-use crate::ipc::{bind_listener, recv_message, send_message, MessageType};
+use crate::ipc::{bind_listener, recv_message, send_message, socket_path, MessageType};
 use crate::repo::LatticeRepo;
 use crate::security::is_quarantined_executable;
 use crate::KeyManager;
@@ -16,7 +16,22 @@ use super::proto as pb;
 
 pub async fn run_ipc_server(repo: LatticeRepo) -> Result<()> {
     let repo = Arc::new(repo);
+    let socket_path = socket_path(&repo);
     let listener = bind_listener(&repo).await?;
+
+    if repo.config.ipc.verbose {
+        eprintln!("✓ IPC server started successfully");
+        eprintln!("  {:<18} {}", "Socket:", socket_path.display());
+        eprintln!("  {:<18} {}", "Protocol:", "Unix domain socket");
+        eprintln!("  {:<18} {}", "Message types:", "ShareRequest, RevokeRequest, FetchRequest, StatusRequest, ShutdownRequest, SyncEvent");
+        eprintln!(
+            "  {:<18} {} MiB",
+            "Max message size:",
+            crate::ipc::MAX_MESSAGE_SIZE / (1024 * 1024)
+        );
+        eprintln!("  Listening for connections...");
+    }
+
     let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
 
     loop {
@@ -107,9 +122,11 @@ async fn handle_connection(
 async fn handle_share_request(repo: &LatticeRepo, request: pb::ShareRequest) -> pb::ShareResponse {
     let result = (|| {
         repo.enforce_rate_limit(1)?;
-        let object_id = object_id_from_bytes(&request.object_id.ok_or_else(|| {
-            LatticeError::Serialization("Missing object_id".to_string())
-        })?)?;
+        let object_id = object_id_from_bytes(
+            &request
+                .object_id
+                .ok_or_else(|| LatticeError::Serialization("Missing object_id".to_string()))?,
+        )?;
         let object = repo.metadata.load_object(&object_id)?;
 
         let permission: Permission = request.capability.parse()?;
@@ -117,20 +134,15 @@ async fn handle_share_request(repo: &LatticeRepo, request: pb::ShareRequest) -> 
         repo.authorize_object_permission(&object, permission, false)?;
 
         let audience = PublicKey::from_did(&request.audience_did)?;
-        let expires_at = request.expires_at.ok_or_else(|| {
-            LatticeError::Serialization("Missing expires_at".to_string())
-        })?;
+        let expires_at = request
+            .expires_at
+            .ok_or_else(|| LatticeError::Serialization("Missing expires_at".to_string()))?;
         let expires_in = duration_until(expires_at.micros);
         let facts = facts_from_map(request.facts);
 
         let identity = load_default_identity()?;
         let capability = Capability::create_with_facts(
-            &identity,
-            &audience,
-            &object_id,
-            permission,
-            expires_in,
-            facts,
+            &identity, &audience, &object_id, permission, expires_in, facts,
         )?;
         repo.metadata.store_capability(&capability)?;
         repo.events.emit_sync(Event::share_issued(
@@ -153,14 +165,21 @@ async fn handle_share_request(repo: &LatticeRepo, request: pb::ShareRequest) -> 
     }
 }
 
-async fn handle_revoke_request(repo: &LatticeRepo, request: pb::RevokeRequest) -> pb::RevokeResponse {
+async fn handle_revoke_request(
+    repo: &LatticeRepo,
+    request: pb::RevokeRequest,
+) -> pb::RevokeResponse {
     let result = (|| {
         repo.enforce_rate_limit(1)?;
         let cap = repo.metadata.load_capability(&request.ucan_cid)?;
         let identity = load_default_identity()?;
         let revocation = cap.revoke(
             &identity,
-            if request.reason.is_empty() { None } else { Some(request.reason.clone()) },
+            if request.reason.is_empty() {
+                None
+            } else {
+                Some(request.reason.clone())
+            },
             None,
             &repo.metadata,
         )?;
@@ -181,9 +200,11 @@ async fn handle_revoke_request(repo: &LatticeRepo, request: pb::RevokeRequest) -
 async fn handle_fetch_request(repo: &LatticeRepo, request: pb::FetchRequest) -> pb::FetchResponse {
     let result: Result<pb::ObjectData> = async {
         repo.enforce_rate_limit(1)?;
-        let object_id = object_id_from_bytes(&request.object_id.ok_or_else(|| {
-            LatticeError::Serialization("Missing object_id".to_string())
-        })?)?;
+        let object_id = object_id_from_bytes(
+            &request
+                .object_id
+                .ok_or_else(|| LatticeError::Serialization("Missing object_id".to_string()))?,
+        )?;
 
         let token = request.ucan_token.clone();
         let capability = Capability::parse(&token)?;
@@ -256,7 +277,10 @@ async fn handle_fetch_request(repo: &LatticeRepo, request: pb::FetchRequest) -> 
     }
 }
 
-async fn handle_status_request(repo: &LatticeRepo, request: pb::StatusRequest) -> Result<pb::StatusResponse> {
+async fn handle_status_request(
+    repo: &LatticeRepo,
+    request: pb::StatusRequest,
+) -> Result<pb::StatusResponse> {
     let stats = if request.include_stats {
         Some(build_stats(repo)?)
     } else {
@@ -305,7 +329,10 @@ fn count_chunks(root: std::path::PathBuf) -> (u64, u64) {
         return (0, 0);
     }
 
-    for entry in walkdir::WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+    for entry in walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
         if entry.file_type().is_file() {
             count += 1;
             if let Ok(meta) = entry.metadata() {
@@ -334,16 +361,14 @@ fn now_micros() -> i64 {
 }
 
 fn object_id_from_bytes(object_id: &pb::ObjectId) -> Result<crate::model::ObjectID> {
-    let uuid = uuid::Uuid::from_slice(&object_id.uuid).map_err(|e| {
-        LatticeError::Serialization(format!("Invalid object id bytes: {}", e))
-    })?;
+    let uuid = uuid::Uuid::from_slice(&object_id.uuid)
+        .map_err(|e| LatticeError::Serialization(format!("Invalid object id bytes: {}", e)))?;
     Ok(crate::model::ObjectID::from_uuid(uuid))
 }
 
 fn version_id_from_bytes(version_id: &pb::VersionId) -> Result<crate::model::VersionID> {
-    let uuid = uuid::Uuid::from_slice(&version_id.uuid).map_err(|e| {
-        LatticeError::Serialization(format!("Invalid version id bytes: {}", e))
-    })?;
+    let uuid = uuid::Uuid::from_slice(&version_id.uuid)
+        .map_err(|e| LatticeError::Serialization(format!("Invalid version id bytes: {}", e)))?;
     Ok(crate::model::VersionID::from_uuid(uuid))
 }
 

--- a/cli/src/commands/ipc.rs
+++ b/cli/src/commands/ipc.rs
@@ -7,7 +7,15 @@ use latticefs_base::LatticeRepo;
 pub struct IpcArgs {
 }
 
-pub async fn run(repo: LatticeRepo, _args: IpcArgs) -> Result<()> {
+pub async fn run(mut repo: LatticeRepo, _args: IpcArgs) -> Result<()> {
+    let socket_path = latticefs_base::ipc::socket_path(&repo);
+    eprintln!("Starting IPC server...");
+    eprintln!("Socket will be available at: {}", socket_path.display());
+    eprintln!("Press Ctrl+C to stop the server\n");
+    
+    // Enable verbose output for CLI usage
+    repo.config.ipc.verbose = true;
+    
     start_ipc_server(repo).await?;
     Ok(())
 }

--- a/cli/src/commands/shares.rs
+++ b/cli/src/commands/shares.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use latticefs_base::crypto::Capability;
 use latticefs_base::LatticeRepo;
+use latticefs_base::crypto::Capability;
 
 #[derive(Subcommand, Debug)]
 pub enum SharesCommand {
@@ -27,19 +27,61 @@ async fn list(repo: LatticeRepo) -> Result<()> {
         return Ok(());
     }
 
+    let mut first = true;
     for (cid, token) in caps {
+        if !first {
+            println!();
+        }
+        first = false;
+
         let parsed = Capability::parse(&token);
         match parsed {
             Ok(cap) => {
-                let subject = cap.payload.sub.clone().unwrap_or_else(|| "(none)".to_string());
-                let perms: Vec<String> = cap.payload.att.iter().map(|a| format!("{}:{}", a.with, a.can)).collect();
-                println!("{}", cid);
-                println!("  subject: {}", subject);
-                println!("  perms: {}", perms.join(", "));
+                let subject = cap
+                    .payload
+                    .sub
+                    .clone()
+                    .unwrap_or_else(|| "(none)".to_string());
+                let perms: Vec<String> = cap
+                    .payload
+                    .att
+                    .iter()
+                    .map(|a| format!("{}:{}", a.with, a.can))
+                    .collect();
+
+                // Format expiration time
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                let exp_timestamp = cap.payload.exp;
+                let is_expired = cap.is_expired();
+                let exp_status = if is_expired {
+                    "expired".to_string()
+                } else {
+                    let remaining = exp_timestamp.saturating_sub(now);
+                    let days = remaining / 86400;
+                    let hours = (remaining % 86400) / 3600;
+                    if days > 0 {
+                        format!("expires in {}d {}h", days, hours)
+                    } else if hours > 0 {
+                        format!("expires in {}h", hours)
+                    } else {
+                        format!("expires in {}s", remaining)
+                    }
+                };
+
+                println!("Share ID: {}", cid);
+                println!("  issuer:   {}", cap.payload.iss);
+                println!("  audience: {}", cap.payload.aud);
+                println!("  subject:  {}", subject);
+                println!("  perms:    {}", perms.join(", "));
+                println!("  status:   {}", exp_status);
             }
             Err(_) => {
-                println!("{}", cid);
+                println!("Share ID: {}", cid);
                 println!("  token: {}", token);
+                println!("  status: invalid (failed to parse capability)");
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add IpcConfig to manage verbose logging for IPC server startup
- Display socket path, protocol, and message types when verbose mode is enabled
- Enhanced shares list output with issuer, audience, and expiration status
- Code formatting improvements for consistency

## Changes
- **base/src/config.rs**: Add IpcConfig struct with verbose boolean flag
- **base/src/ipc/server.rs**: Implement verbose logging in run_ipc_server startup
- **cli/src/commands/ipc.rs**: Enable verbose output for CLI usage
- **cli/src/commands/shares.rs**: Improve shares list formatting and add expiration status

## Test plan
- [x] Run `lattice ipc` and verify verbose startup output
- [x] Run `lattice shares list` and verify improved formatting
- [x] Verify config serialization/deserialization for IpcConfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)