### PR TITLE
Skip CI workflow on draft pull requests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds a condition to skip the CI workflow when triggered by draft pull requests. This prevents unnecessary CI runs while PRs are still in progress.