### PR TITLE
Implement onboarding logic bridge: lfs-gui API + frontend wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base"
 version = "0.1.0"
 dependencies = [
@@ -667,18 +722,22 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "axum",
  "base",
  "base64",
  "clap",
  "dirs",
  "hex",
+ "humantime",
  "indicatif",
  "predicates",
  "serde",
+ "serde_json",
  "similar",
  "tempfile",
  "tokio",
  "toml",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1153,6 +1212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1243,15 @@ dependencies = [
  "pkg-config",
  "smallvec",
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1377,6 +1454,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1659,6 +1823,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
@@ -2000,6 +2170,12 @@ dependencies = [
  "type1-encoding-parser",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -2534,6 +2710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,6 +2822,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,6 +2849,18 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2824,6 +3029,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tar"
@@ -3021,11 +3232,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 latticefs-base = { package = "base", path = "../base" }
+axum = "0.7"
 clap = { version = "4.5", features = ["derive", "env", "color"] }
 anyhow = "1.0"
 tokio = { version = "1.36", features = ["full"] }
@@ -16,6 +17,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 indicatif = "0.17"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.8"
 similar = "2.4"
 walkdir = "2.5"
@@ -23,6 +25,8 @@ uuid = { version = "1", features = ["v4", "v7"] }
 dirs = "5.0"
 hex = "0.4"
 base64 = "0.22"
+tower-http = { version = "0.5", features = ["cors"] }
+humantime = "2.1"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/cli/src/bin/lfs-gui.rs
+++ b/cli/src/bin/lfs-gui.rs
@@ -1,0 +1,909 @@
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use latticefs_base::{
+    LatticeRepo,
+    config::default_home,
+    import::{ImportOptions, import_file, scanner},
+    model::Tag,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tower_http::cors::{Any, CorsLayer};
+use tracing::info;
+
+use cli::commands::common::{ensure_identity, identity_actor, open_repo};
+
+#[derive(Clone, Default)]
+struct AppState;
+
+#[derive(Debug, Serialize)]
+struct ApiError {
+    message: String,
+}
+
+impl ApiError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl From<anyhow::Error> for ApiError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::new(err.to_string())
+    }
+}
+
+impl From<latticefs_base::error::LatticeError> for ApiError {
+    fn from(err: latticefs_base::error::LatticeError) -> Self {
+        Self::new(err.to_string())
+    }
+}
+
+type ApiResult<T> = Result<T, (StatusCode, Json<ApiError>)>;
+
+#[derive(Debug, Serialize)]
+struct StatusResponse {
+    repo_path: String,
+    version: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FolderOption {
+    id: String,
+    name: String,
+    path: String,
+    exists: bool,
+    default_selected: bool,
+    is_demo: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct OnboardingSettings {
+    quarantine_downloads: bool,
+    versioning: bool,
+    execute_warning: bool,
+}
+
+impl Default for OnboardingSettings {
+    fn default() -> Self {
+        Self {
+            quarantine_downloads: true,
+            versioning: true,
+            execute_warning: true,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SettingsResponse {
+    settings: OnboardingSettings,
+}
+
+#[derive(Debug, Serialize)]
+struct ImportSummary {
+    folder_id: String,
+    files: usize,
+    objects: usize,
+    bytes: u64,
+    errors: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ImportResponse {
+    summaries: Vec<ImportSummary>,
+    total_files: usize,
+    total_objects: usize,
+    total_bytes: u64,
+    errors: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportRequest {
+    folder_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateSettingsRequest {
+    quarantine_downloads: bool,
+    versioning: bool,
+    execute_warning: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SeedResponse {
+    demo_root: String,
+    folders: Vec<FolderOption>,
+}
+
+#[derive(Debug, Serialize)]
+struct OnboardingView {
+    id: String,
+    name: String,
+    icon: String,
+    description: String,
+    color: String,
+}
+
+#[derive(Debug, Serialize)]
+struct OnboardingFile {
+    id: String,
+    name: String,
+    extension: Option<String>,
+    size_bytes: u64,
+    created_at: String,
+    tags: Vec<String>,
+    views: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct OnboardingProject {
+    id: String,
+    name: String,
+    color: String,
+}
+
+#[derive(Debug, Serialize)]
+struct OnboardingDataResponse {
+    views: Vec<OnboardingView>,
+    files: Vec<OnboardingFile>,
+    projects: Vec<OnboardingProject>,
+    highlighted_file_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AssignProjectRequest {
+    object_id: String,
+    project_id: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let app = Router::new()
+        .route("/api/status", get(status))
+        .route("/api/onboarding/init", post(init_repo))
+        .route("/api/onboarding/folders", get(list_folders))
+        .route("/api/onboarding/seed-files", post(seed_demo_files))
+        .route("/api/onboarding/import", post(import_folders))
+        .route(
+            "/api/onboarding/settings",
+            get(get_settings).post(update_settings),
+        )
+        .route("/api/onboarding/data", get(get_onboarding_data))
+        .route("/api/onboarding/assign-project", post(assign_project))
+        .layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_headers(Any)
+                .allow_methods(Any),
+        )
+        .with_state(AppState::default());
+
+    let port = std::env::var("LFS_GUI_PORT")
+        .ok()
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(8788);
+    let addr = format!("0.0.0.0:{port}");
+    info!("LatticeFS GUI API listening on {addr}");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn status(State(_state): State<AppState>) -> ApiResult<Json<StatusResponse>> {
+    let repo = open_repo(None).map_err(api_error)?;
+    Ok(Json(StatusResponse {
+        repo_path: repo.root.to_string_lossy().to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    }))
+}
+
+async fn init_repo(State(_state): State<AppState>) -> ApiResult<Json<StatusResponse>> {
+    let repo = tokio::task::spawn_blocking(|| LatticeRepo::init())
+        .await
+        .map_err(|err| api_error(anyhow::Error::new(err)))?
+        .map_err(|err| api_error(anyhow::Error::new(err)))?;
+    Ok(Json(StatusResponse {
+        repo_path: repo.root.to_string_lossy().to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    }))
+}
+
+async fn list_folders(State(_state): State<AppState>) -> ApiResult<Json<Vec<FolderOption>>> {
+    Ok(Json(build_folder_options()))
+}
+
+async fn seed_demo_files(State(_state): State<AppState>) -> ApiResult<Json<SeedResponse>> {
+    let demo_root = demo_root();
+    create_demo_files(&demo_root).map_err(api_error)?;
+    Ok(Json(SeedResponse {
+        demo_root: demo_root.to_string_lossy().to_string(),
+        folders: build_folder_options(),
+    }))
+}
+
+async fn get_settings(State(_state): State<AppState>) -> ApiResult<Json<SettingsResponse>> {
+    Ok(Json(SettingsResponse {
+        settings: load_settings().map_err(api_error)?,
+    }))
+}
+
+async fn update_settings(
+    State(_state): State<AppState>,
+    Json(payload): Json<UpdateSettingsRequest>,
+) -> ApiResult<Json<SettingsResponse>> {
+    let settings = OnboardingSettings {
+        quarantine_downloads: payload.quarantine_downloads,
+        versioning: payload.versioning,
+        execute_warning: payload.execute_warning,
+    };
+    save_settings(&settings).map_err(api_error)?;
+    Ok(Json(SettingsResponse { settings }))
+}
+
+async fn import_folders(
+    State(_state): State<AppState>,
+    Json(payload): Json<ImportRequest>,
+) -> ApiResult<Json<ImportResponse>> {
+    let repo = open_repo(None).map_err(api_error)?;
+    let identity = ensure_identity("default", None).map_err(api_error)?;
+    let actor = identity_actor(&identity);
+    let settings = load_settings().map_err(api_error)?;
+    let folder_map = folder_definitions();
+
+    let mut summaries = Vec::new();
+    let mut total_files = 0usize;
+    let mut total_objects = 0usize;
+    let mut total_bytes = 0u64;
+    let mut errors = Vec::new();
+
+    for folder_id in payload.folder_ids {
+        let folder = folder_map
+            .iter()
+            .find(|entry| entry.id == folder_id)
+            .ok_or_else(|| api_error(anyhow::anyhow!("Unknown folder: {}", folder_id)))?;
+
+        let path = folder.path.clone();
+        if !path.exists() {
+            errors.push(format!("{} does not exist", path.display()));
+            continue;
+        }
+
+        let summary = import_folder(&repo, folder, actor, &settings)
+            .await
+            .map_err(api_error)?;
+        total_files += summary.files;
+        total_objects += summary.objects;
+        total_bytes += summary.bytes;
+        errors.extend(summary.errors.clone());
+        summaries.push(summary);
+    }
+
+    Ok(Json(ImportResponse {
+        summaries,
+        total_files,
+        total_objects,
+        total_bytes,
+        errors,
+    }))
+}
+
+async fn get_onboarding_data(
+    State(_state): State<AppState>,
+) -> ApiResult<Json<OnboardingDataResponse>> {
+    let repo = open_repo(None).map_err(api_error)?;
+    let data = build_onboarding_data(&repo).map_err(api_error)?;
+    Ok(Json(data))
+}
+
+async fn assign_project(
+    State(_state): State<AppState>,
+    Json(payload): Json<AssignProjectRequest>,
+) -> ApiResult<Json<OnboardingDataResponse>> {
+    let repo = open_repo(None).map_err(api_error)?;
+    let identity = ensure_identity("default", None).map_err(api_error)?;
+    let actor = identity_actor(&identity);
+    let object_id = uuid::Uuid::parse_str(&payload.object_id)
+        .map_err(|_| api_error(anyhow::anyhow!("Invalid object id")))?;
+    let object_id = latticefs_base::model::ObjectID::from_uuid(object_id);
+    let tag = Tag::new("project".to_string(), payload.project_id.clone(), actor);
+    apply_tags(&repo, &object_id, vec![tag]).map_err(api_error)?;
+    let data = build_onboarding_data(&repo).map_err(api_error)?;
+    Ok(Json(data))
+}
+
+fn api_error(err: anyhow::Error) -> (StatusCode, Json<ApiError>) {
+    (StatusCode::BAD_REQUEST, Json(ApiError::from(err)))
+}
+
+fn settings_path() -> PathBuf {
+    default_home().join("gui").join("settings.json")
+}
+
+fn load_settings() -> anyhow::Result<OnboardingSettings> {
+    let path = settings_path();
+    if !path.exists() {
+        return Ok(OnboardingSettings::default());
+    }
+    let data = std::fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&data)?)
+}
+
+fn save_settings(settings: &OnboardingSettings) -> anyhow::Result<()> {
+    let path = settings_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, serde_json::to_string_pretty(settings)?)?;
+    Ok(())
+}
+
+struct FolderDefinition {
+    id: String,
+    name: String,
+    path: PathBuf,
+    default_selected: bool,
+    is_demo: bool,
+}
+
+fn demo_root() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("LatticeDemo")
+}
+
+fn folder_definitions() -> Vec<FolderDefinition> {
+    let mut folders = Vec::new();
+    let documents = dirs::document_dir();
+    let downloads = dirs::download_dir();
+    let pictures = dirs::picture_dir();
+    let projects = dirs::home_dir().map(|home| home.join("Projects"));
+
+    if let Some(path) = documents {
+        folders.push(FolderDefinition {
+            id: "documents".to_string(),
+            name: "Dokumente".to_string(),
+            path,
+            default_selected: true,
+            is_demo: false,
+        });
+    }
+
+    if let Some(path) = downloads {
+        folders.push(FolderDefinition {
+            id: "downloads".to_string(),
+            name: "Downloads".to_string(),
+            path,
+            default_selected: true,
+            is_demo: false,
+        });
+    }
+
+    if let Some(path) = pictures {
+        folders.push(FolderDefinition {
+            id: "bilder".to_string(),
+            name: "Bilder".to_string(),
+            path,
+            default_selected: false,
+            is_demo: false,
+        });
+    }
+
+    if let Some(path) = projects {
+        folders.push(FolderDefinition {
+            id: "projekte".to_string(),
+            name: "Projekte".to_string(),
+            path,
+            default_selected: false,
+            is_demo: false,
+        });
+    }
+
+    let demo = demo_root();
+    if demo.exists() {
+        folders.push(FolderDefinition {
+            id: "demo".to_string(),
+            name: "Demo-Dateien".to_string(),
+            path: demo,
+            default_selected: false,
+            is_demo: true,
+        });
+    }
+
+    folders
+}
+
+fn build_folder_options() -> Vec<FolderOption> {
+    folder_definitions()
+        .into_iter()
+        .map(|folder| FolderOption {
+            id: folder.id,
+            name: folder.name,
+            path: folder.path.to_string_lossy().to_string(),
+            exists: folder.path.exists(),
+            default_selected: folder.default_selected,
+            is_demo: folder.is_demo,
+        })
+        .collect()
+}
+
+fn create_demo_files(root: &Path) -> anyhow::Result<()> {
+    let documents = root.join("Documents");
+    let downloads = root.join("Downloads");
+    let pictures = root.join("Pictures");
+    let projects = root.join("Projects");
+    let phoenix = projects.join("Phoenix");
+    let aurora = projects.join("Aurora");
+    let nebula = projects.join("Nebula");
+
+    for dir in [
+        &documents, &downloads, &pictures, &phoenix, &aurora, &nebula,
+    ] {
+        std::fs::create_dir_all(dir)?;
+    }
+
+    std::fs::write(
+        documents.join("Projektplan_Phoenix.md"),
+        "Projektplan für Phoenix\n\n- Ziele\n- Timeline\n",
+    )?;
+    std::fs::write(
+        documents.join("Budget_2024.txt"),
+        "Budget 2024\nMarketing: 12000\nForschung: 35000\n",
+    )?;
+    std::fs::write(
+        downloads.join("setup_installer.exe"),
+        "Pretend binary content",
+    )?;
+    std::fs::write(
+        downloads.join("invoice_2024.pdf"),
+        "%PDF-1.4\n1 0 obj\n<<>>\nendobj\n",
+    )?;
+    std::fs::write(
+        pictures.join("Urlaub_Mallorca_2023.jpg"),
+        "Not a real JPEG but enough for demo",
+    )?;
+    std::fs::write(
+        phoenix.join("Meeting_Notes.md"),
+        "Meeting Notes\n\n- Entscheidungen\n- Aufgaben\n",
+    )?;
+    std::fs::write(
+        aurora.join("Pitch.pptx"),
+        "Placeholder content for Aurora pitch deck",
+    )?;
+    std::fs::write(
+        nebula.join("Roadmap.xlsx"),
+        "Placeholder content for Nebula roadmap",
+    )?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let exe_path = downloads.join("setup_installer.exe");
+        if let Ok(meta) = std::fs::metadata(&exe_path) {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o755);
+            let _ = std::fs::set_permissions(exe_path, perms);
+        }
+    }
+
+    Ok(())
+}
+
+async fn import_folder(
+    repo: &LatticeRepo,
+    folder: &FolderDefinition,
+    actor: [u8; 32],
+    settings: &OnboardingSettings,
+) -> anyhow::Result<ImportSummary> {
+    let entries = scanner::scan_path(&folder.path)?;
+    let mut files = 0usize;
+    let mut objects = 0usize;
+    let mut bytes = 0u64;
+    let mut errors = Vec::new();
+
+    for entry in entries {
+        files += 1;
+        bytes += entry.size;
+        let mut options = ImportOptions {
+            tags: Vec::new(),
+            extract_exif: repo.config.import.extract_exif,
+            extract_id3: repo.config.import.extract_id3,
+            extract_text: repo.config.import.extract_text,
+            actor,
+            base_path: if folder.path.is_dir() {
+                Some(folder.path.clone())
+            } else {
+                None
+            },
+        };
+
+        if folder.id != "demo" {
+            options.tags.push(format!("folder:{}", folder.id));
+        }
+
+        match import_file(repo, &entry.path, &options).await {
+            Ok(object_id) => {
+                objects += 1;
+                let tag_updates =
+                    build_post_import_tags(folder, &entry.path, &options, settings, actor);
+                if let Err(err) = apply_tags(repo, &object_id, tag_updates) {
+                    errors.push(format!("{}: {}", entry.path.display(), err));
+                }
+            }
+            Err(err) => errors.push(format!("{}: {}", entry.path.display(), err)),
+        }
+    }
+
+    Ok(ImportSummary {
+        folder_id: folder.id.clone(),
+        files,
+        objects,
+        bytes,
+        errors,
+    })
+}
+
+fn build_post_import_tags(
+    folder: &FolderDefinition,
+    path: &Path,
+    options: &ImportOptions,
+    settings: &OnboardingSettings,
+    actor: [u8; 32],
+) -> Vec<Tag> {
+    let mut tags = Vec::new();
+    let mut folder_id = folder.id.clone();
+
+    if folder.id == "demo" {
+        if let Some(base) = &options.base_path {
+            if let Ok(rel) = path.strip_prefix(base) {
+                if let Some(component) = rel.components().next() {
+                    let name = component.as_os_str().to_string_lossy().to_lowercase();
+                    folder_id = match name.as_str() {
+                        "documents" => "documents".to_string(),
+                        "downloads" => "downloads".to_string(),
+                        "pictures" => "bilder".to_string(),
+                        "projects" => "projekte".to_string(),
+                        _ => "demo".to_string(),
+                    };
+                }
+            }
+        }
+    }
+
+    tags.push(Tag::new("folder".to_string(), folder_id.clone(), actor));
+
+    if folder_id == "downloads" {
+        tags.push(Tag::new(
+            "inbox".to_string(),
+            "downloads".to_string(),
+            actor,
+        ));
+        if settings.quarantine_downloads {
+            tags.push(Tag::new(
+                "risk".to_string(),
+                "quarantine".to_string(),
+                actor,
+            ));
+        }
+    }
+
+    if folder_id == "projekte" {
+        if let Some(base) = &options.base_path {
+            if let Ok(rel) = path.strip_prefix(base) {
+                let mut components = rel.components();
+                let first = components
+                    .next()
+                    .map(|component| component.as_os_str().to_string_lossy().to_string());
+                let project = if folder.id == "demo"
+                    && first
+                        .as_deref()
+                        .is_some_and(|name| name.eq_ignore_ascii_case("Projects"))
+                {
+                    components
+                        .next()
+                        .map(|component| component.as_os_str().to_string_lossy().to_string())
+                } else {
+                    first
+                };
+                if let Some(project) = project {
+                    if !project.is_empty() {
+                        tags.push(Tag::new("project".to_string(), project, actor));
+                    }
+                }
+            }
+        }
+    }
+
+    let extension = path
+        .extension()
+        .map(|ext| ext.to_string_lossy().to_lowercase());
+    let is_executable = extension
+        .as_deref()
+        .is_some_and(|ext| matches!(ext, "exe" | "bat" | "cmd" | "sh" | "app"));
+
+    if is_executable {
+        tags.push(Tag::new(
+            "auto:executable".to_string(),
+            "true".to_string(),
+            actor,
+        ));
+        if settings.execute_warning {
+            tags.push(Tag::new("sys:trust".to_string(), "50".to_string(), actor));
+        }
+    }
+
+    tags
+}
+
+fn apply_tags(
+    repo: &LatticeRepo,
+    object_id: &latticefs_base::model::ObjectID,
+    tags: Vec<Tag>,
+) -> anyhow::Result<()> {
+    if tags.is_empty() {
+        return Ok(());
+    }
+    let mut object = repo.metadata.load_object(object_id)?;
+    let mut new_tags = Vec::new();
+
+    for tag in tags {
+        if object
+            .tags
+            .iter()
+            .any(|existing| existing.key == tag.key && existing.value == tag.value)
+        {
+            continue;
+        }
+        object.add_tag(tag.clone());
+        new_tags.push(tag.full_path());
+    }
+
+    if new_tags.is_empty() {
+        return Ok(());
+    }
+
+    repo.metadata.store_object(&object)?;
+    for tag in new_tags {
+        repo.metadata.add_to_tag_index(&tag, object_id.as_bytes())?;
+    }
+    Ok(())
+}
+
+struct FileSummary {
+    id: String,
+    name: String,
+    extension: Option<String>,
+    size_bytes: u64,
+    created_at: i64,
+    tags: Vec<Tag>,
+}
+
+struct ViewDefinition {
+    id: &'static str,
+    name: &'static str,
+    icon: &'static str,
+    description: &'static str,
+    color: &'static str,
+    predicate: fn(&FileSummary) -> bool,
+}
+
+fn build_onboarding_data(repo: &LatticeRepo) -> anyhow::Result<OnboardingDataResponse> {
+    let mut files = Vec::new();
+    for item in repo.metadata.iter_objects() {
+        let object = match item {
+            Ok(obj) => obj,
+            Err(err) => {
+                tracing::warn!("Failed to read object: {err}");
+                continue;
+            }
+        };
+        let version = repo.metadata.load_version(&object.current_version)?;
+        let (name, extension) = extract_name(&object.tags, &object.id.to_string());
+        files.push(FileSummary {
+            id: object.id.to_string(),
+            name,
+            extension,
+            size_bytes: version.size_bytes,
+            created_at: version.created_at,
+            tags: object.tags,
+        });
+    }
+
+    let view_defs = view_definitions();
+    let mut views = Vec::new();
+    let mut api_files = Vec::new();
+    let mut view_counts: HashMap<&str, usize> = HashMap::new();
+
+    for file in &files {
+        let mut file_views = Vec::new();
+        for view in &view_defs {
+            if (view.predicate)(file) {
+                file_views.push(view.id.to_string());
+                *view_counts.entry(view.id).or_insert(0) += 1;
+            }
+        }
+        api_files.push(OnboardingFile {
+            id: file.id.clone(),
+            name: file.name.clone(),
+            extension: file.extension.clone(),
+            size_bytes: file.size_bytes,
+            created_at: timestamp_to_iso(file.created_at),
+            tags: file.tags.iter().map(Tag::full_path).collect(),
+            views: file_views,
+        });
+    }
+
+    for view in view_defs {
+        if view_counts.get(view.id).copied().unwrap_or(0) > 0 {
+            views.push(OnboardingView {
+                id: view.id.to_string(),
+                name: view.name.to_string(),
+                icon: view.icon.to_string(),
+                description: view.description.to_string(),
+                color: view.color.to_string(),
+            });
+        }
+    }
+
+    let projects = build_projects(&files);
+    let highlighted_file_id = select_highlighted_file(&files);
+
+    Ok(OnboardingDataResponse {
+        views,
+        files: api_files,
+        projects,
+        highlighted_file_id,
+    })
+}
+
+fn view_definitions() -> Vec<ViewDefinition> {
+    vec![
+        ViewDefinition {
+            id: "recent",
+            name: "Neueste",
+            icon: "Clock",
+            description: "Zuletzt importierte Objekte",
+            color: "primary",
+            predicate: |file| is_recent(file, Duration::from_secs(60 * 60 * 24 * 7)),
+        },
+        ViewDefinition {
+            id: "downloads",
+            name: "Downloads",
+            icon: "Download",
+            description: "Alles aus deinen Downloads",
+            color: "warning",
+            predicate: |file| {
+                has_tag(file, "folder", "downloads") || has_tag(file, "inbox", "downloads")
+            },
+        },
+        ViewDefinition {
+            id: "quarantine",
+            name: "Quarantäne",
+            icon: "Shield",
+            description: "Objekte mit Sicherheitsflag",
+            color: "warning",
+            predicate: |file| {
+                has_tag(file, "risk", "quarantine") || has_tag(file, "sys:trust", "50")
+            },
+        },
+        ViewDefinition {
+            id: "documents",
+            name: "Dokumente",
+            icon: "Grid",
+            description: "Text, Tabellen und PDFs",
+            color: "muted",
+            predicate: |file| has_tag(file, "folder", "documents"),
+        },
+        ViewDefinition {
+            id: "bilder",
+            name: "Bilder",
+            icon: "Grid",
+            description: "Fotos und Bilder",
+            color: "muted",
+            predicate: |file| has_tag(file, "folder", "bilder"),
+        },
+        ViewDefinition {
+            id: "projekte",
+            name: "Projekte",
+            icon: "Folder",
+            description: "Projektbezogene Dateien",
+            color: "secondary",
+            predicate: |file| {
+                has_tag(file, "folder", "projekte") || has_tag_prefix(file, "project")
+            },
+        },
+    ]
+}
+
+fn is_recent(file: &FileSummary, window: Duration) -> bool {
+    let created_at = file.created_at as i64;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0))
+        .as_micros() as i64;
+    now.saturating_sub(created_at) <= window.as_micros() as i64
+}
+
+fn has_tag(file: &FileSummary, key: &str, value: &str) -> bool {
+    file.tags
+        .iter()
+        .any(|tag| tag.key == key && tag.value == value)
+}
+
+fn has_tag_prefix(file: &FileSummary, prefix: &str) -> bool {
+    file.tags.iter().any(|tag| tag.key.starts_with(prefix))
+}
+
+fn build_projects(files: &[FileSummary]) -> Vec<OnboardingProject> {
+    let mut projects = HashSet::new();
+    for file in files {
+        for tag in &file.tags {
+            if tag.key == "project" {
+                projects.insert(tag.value.clone());
+            }
+        }
+    }
+
+    let palette = ["#8B5CF6", "#38BDF8", "#F59E0B", "#34D399", "#F472B6"];
+
+    projects
+        .into_iter()
+        .enumerate()
+        .map(|(idx, name)| OnboardingProject {
+            id: name.clone(),
+            name,
+            color: palette[idx % palette.len()].to_string(),
+        })
+        .collect()
+}
+
+fn select_highlighted_file(files: &[FileSummary]) -> Option<String> {
+    files
+        .iter()
+        .find(|file| has_tag(file, "risk", "quarantine"))
+        .or_else(|| {
+            files
+                .iter()
+                .find(|file| has_tag(file, "inbox", "downloads"))
+        })
+        .or_else(|| {
+            files
+                .iter()
+                .find(|file| file.extension.as_deref() == Some("exe"))
+        })
+        .map(|file| file.id.clone())
+}
+
+fn extract_name(tags: &[Tag], fallback: &str) -> (String, Option<String>) {
+    let file_name = tags
+        .iter()
+        .find(|tag| tag.key == "auto:filename_b64")
+        .and_then(|tag| URL_SAFE_NO_PAD.decode(&tag.value).ok())
+        .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+        .unwrap_or_else(|| fallback.to_string());
+
+    let extension = Path::new(&file_name)
+        .extension()
+        .map(|ext| ext.to_string_lossy().to_lowercase());
+
+    (file_name, extension)
+}
+
+fn timestamp_to_iso(micros: i64) -> String {
+    let secs = micros.div_euclid(1_000_000) as u64;
+    let nanos = (micros.rem_euclid(1_000_000) as u32) * 1_000;
+    let timestamp = UNIX_EPOCH + Duration::new(secs, nanos);
+    humantime::format_rfc3339(timestamp).to_string()
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod commands;

--- a/gui/src/components/onboarding/AhaTutorial.tsx
+++ b/gui/src/components/onboarding/AhaTutorial.tsx
@@ -1,12 +1,17 @@
 import { useState, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { mockFiles, mockViews, mockProjects, getFileById, ViewNode } from "@/data/mockFileSystem";
+import { getFileById, type FileNode, type ProjectNode, type ViewNode } from "@/data/onboardingData";
 import { Clock, Folder, Grid, Download, Shield, HelpCircle, Plus, X, Check, Sparkles } from "lucide-react";
 import { AnimatedButton } from "./ui/AnimatedButton";
 import { GlassCard } from "./ui/GlassCard";
 
 interface AhaTutorialProps {
   onComplete: () => void;
+  views: ViewNode[];
+  files: FileNode[];
+  projects: ProjectNode[];
+  highlightedFileId: string | null;
+  onAssignProject: (objectId: string, projectId: string) => Promise<void>;
 }
 
 const viewIcons: Record<string, typeof Clock> = {
@@ -26,16 +31,25 @@ const colorClasses: Record<string, { bg: string; border: string; text: string }>
 
 type TutorialStep = "highlight" | "context" | "add-project" | "complete";
 
-export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
+export const AhaTutorial = ({
+  onComplete,
+  views,
+  files,
+  projects,
+  highlightedFileId,
+  onAssignProject,
+}: AhaTutorialProps) => {
   const [step, setStep] = useState<TutorialStep>("highlight");
   const [showContextPanel, setShowContextPanel] = useState(false);
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
   const [showConnectionAnimation, setShowConnectionAnimation] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
   // The highlighted file for the tutorial
-  const highlightedFile = mockFiles.find((f) => f.id === "file-3"); // setup_installer.exe
+  const highlightedFile =
+    (highlightedFileId ? getFileById(files, highlightedFileId) : null) ?? files[0];
   
   useEffect(() => {
     if (step === "complete") {
@@ -50,17 +64,31 @@ export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
     setStep("context");
   };
 
-  const handleAddToProject = (projectId: string) => {
+  const handleAddToProject = async (projectId: string) => {
+    if (!highlightedFile) return;
+    setActionError(null);
     setSelectedProject(projectId);
     setShowConnectionAnimation(true);
-    
-    setTimeout(() => {
+    try {
+      await onAssignProject(highlightedFile.id, projectId);
+      setTimeout(() => {
+        setShowConnectionAnimation(false);
+        setStep("complete");
+      }, 1500);
+    } catch (err) {
       setShowConnectionAnimation(false);
-      setStep("complete");
-    }, 1500);
+      if (err instanceof Error) {
+        setActionError(err.message);
+      } else {
+        setActionError("Projekt konnte nicht hinzugefügt werden.");
+      }
+    }
   };
 
   const getViewPosition = (index: number, total: number) => {
+    if (total === 0) {
+      return { x: 0, y: 0 };
+    }
     const angle = (index / total) * Math.PI * 2 - Math.PI / 2;
     const radius = 160;
     return {
@@ -109,8 +137,8 @@ export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
         
         <g transform={`translate(${containerRef.current?.clientWidth ? containerRef.current.clientWidth / 2 - 150 : 350}, ${containerRef.current?.clientHeight ? containerRef.current.clientHeight / 2 : 400})`}>
           {/* Existing connections */}
-          {mockViews.map((view, index) => {
-            const pos = getViewPosition(index, mockViews.length);
+          {views.map((view, index) => {
+            const pos = getViewPosition(index, views.length);
             return (
               <line
                 key={`hub-${view.id}`}
@@ -128,10 +156,10 @@ export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
           {/* New connection animation */}
           {showConnectionAnimation && selectedProject && (
             <line
-              x1={getViewPosition(4, mockViews.length).x - 30}
-              y1={getViewPosition(4, mockViews.length).y}
-              x2={getViewPosition(1, mockViews.length).x}
-              y2={getViewPosition(1, mockViews.length).y}
+              x1={getViewPosition(Math.max(views.length - 1, 0), views.length).x - 30}
+              y1={getViewPosition(Math.max(views.length - 1, 0), views.length).y}
+              x2={getViewPosition(1, views.length).x}
+              y2={getViewPosition(1, views.length).y}
               stroke="hsl(var(--secondary))"
               strokeWidth="2"
               strokeDasharray="1000"
@@ -154,8 +182,8 @@ export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
         </div>
         
         {/* View nodes */}
-        {mockViews.map((view, index) => {
-          const pos = getViewPosition(index, mockViews.length);
+        {views.map((view, index) => {
+          const pos = getViewPosition(index, views.length);
           const Icon = viewIcons[view.icon] || Folder;
           const colors = colorClasses[view.color];
           const isProjectView = view.id === "projekte";
@@ -191,7 +219,7 @@ export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
               step === "highlight" && "animate-node-pulse"
             )}
             style={{
-              transform: `translate(calc(-50% + ${getViewPosition(4, mockViews.length).x - 30}px), calc(-50% + ${getViewPosition(4, mockViews.length).y}px))`,
+              transform: `translate(calc(-50% + ${getViewPosition(Math.max(views.length - 1, 0), views.length).x - 30}px), calc(-50% + ${getViewPosition(Math.max(views.length - 1, 0), views.length).y}px))`,
             }}
             onClick={handleWhyClick}
           >
@@ -247,20 +275,34 @@ export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
             </div>
             
             <div className="space-y-3 mb-6">
-              <div className="flex items-center gap-3 text-sm">
-                <Clock className="w-4 h-4 text-primary" />
-                <span className="text-muted-foreground">Heute heruntergeladen</span>
-              </div>
-              <div className="flex items-center gap-3 text-sm">
-                <Download className="w-4 h-4 text-warning" />
-                <span className="text-muted-foreground">
-                  Tag: <span className="text-warning">inbox:downloads</span>
-                </span>
-              </div>
-              <div className="flex items-center gap-3 text-sm">
-                <Shield className="w-4 h-4 text-warning" />
-                <span className="text-muted-foreground">In Quarantäne</span>
-              </div>
+              {highlightedFile.tags.some((tag) => tag.startsWith("inbox:")) && (
+                <div className="flex items-center gap-3 text-sm">
+                  <Download className="w-4 h-4 text-warning" />
+                  <span className="text-muted-foreground">
+                    Tag:{" "}
+                    <span className="text-warning">
+                      {highlightedFile.tags.find((tag) => tag.startsWith("inbox:"))}
+                    </span>
+                  </span>
+                </div>
+              )}
+              {highlightedFile.tags.some((tag) => tag === "risk:quarantine") && (
+                <div className="flex items-center gap-3 text-sm">
+                  <Shield className="w-4 h-4 text-warning" />
+                  <span className="text-muted-foreground">In Quarantäne</span>
+                </div>
+              )}
+              {highlightedFile.tags.some((tag) => tag.startsWith("project:")) && (
+                <div className="flex items-center gap-3 text-sm">
+                  <Clock className="w-4 h-4 text-primary" />
+                  <span className="text-muted-foreground">
+                    Projekt:{" "}
+                    <span className="text-primary">
+                      {highlightedFile.tags.find((tag) => tag.startsWith("project:"))?.replace("project:", "")}
+                    </span>
+                  </span>
+                </div>
+              )}
             </div>
             
             {step === "context" && (
@@ -270,7 +312,12 @@ export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
                     Zu einem Projekt hinzufügen?
                   </p>
                   <div className="space-y-2">
-                    {mockProjects.map((project) => (
+                    {projects.length === 0 && (
+                      <p className="text-xs text-muted-foreground">
+                        Noch keine Projekte gefunden. Importiere Projektdateien, um Vorschläge zu sehen.
+                      </p>
+                    )}
+                    {projects.map((project) => (
                       <button
                         key={project.id}
                         onClick={() => handleAddToProject(project.id)}
@@ -289,6 +336,9 @@ export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
                       </button>
                     ))}
                   </div>
+                  {actionError && (
+                    <p className="mt-3 text-xs text-warning">{actionError}</p>
+                  )}
                 </div>
               </>
             )}
@@ -296,7 +346,7 @@ export const AhaTutorial = ({ onComplete }: AhaTutorialProps) => {
             {step === "add-project" && selectedProject && (
               <div className="flex items-center gap-2 text-sm text-secondary">
                 <Check className="w-4 h-4" />
-                <span>Hinzugefügt zu {mockProjects.find((p) => p.id === selectedProject)?.name}</span>
+                <span>Hinzugefügt zu {projects.find((p) => p.id === selectedProject)?.name}</span>
               </div>
             )}
           </GlassCard>

--- a/gui/src/components/onboarding/FolderSelection.tsx
+++ b/gui/src/components/onboarding/FolderSelection.tsx
@@ -1,36 +1,57 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { GlassCard } from "./ui/GlassCard";
 import { AnimatedButton } from "./ui/AnimatedButton";
 import { ToggleSwitch } from "./ui/ToggleSwitch";
 import { ParticleBackground } from "./ui/ParticleBackground";
 import { cn } from "@/lib/utils";
 import { FileText, Download, Image, Code, FolderPlus, Loader2 } from "lucide-react";
+import type { FolderOption } from "@/lib/latticeApi";
 
 interface FolderSelectionProps {
   onNext: () => void;
+  folderOptions: FolderOption[];
+  folderError: string | null;
+  onImport: (folderIds: string[]) => Promise<ImportResponse>;
+  onSeedDemo: () => Promise<{ demoRoot: string; folders: FolderOption[] }>;
 }
 
-interface FolderOption {
-  id: string;
-  name: string;
-  icon: typeof FileText;
-  defaultSelected: boolean;
-}
+const iconMap: Record<string, typeof FileText> = {
+  documents: FileText,
+  downloads: Download,
+  bilder: Image,
+  projekte: Code,
+  demo: FolderPlus,
+};
 
-const folderOptions: FolderOption[] = [
-  { id: "dokumente", name: "Dokumente", icon: FileText, defaultSelected: true },
-  { id: "downloads", name: "Downloads", icon: Download, defaultSelected: true },
-  { id: "bilder", name: "Bilder", icon: Image, defaultSelected: false },
-  { id: "projekte", name: "Projekte", icon: Code, defaultSelected: false },
-];
-
-export const FolderSelection = ({ onNext }: FolderSelectionProps) => {
+export const FolderSelection = ({
+  onNext,
+  folderOptions,
+  folderError,
+  onImport,
+  onSeedDemo,
+}: FolderSelectionProps) => {
   const [selectedFolders, setSelectedFolders] = useState<Set<string>>(
-    new Set(folderOptions.filter((f) => f.defaultSelected).map((f) => f.id))
+    new Set()
   );
   const [isScanning, setIsScanning] = useState(false);
   const [scanProgress, setScanProgress] = useState(0);
   const [currentScanFolder, setCurrentScanFolder] = useState("");
+  const [seedMessage, setSeedMessage] = useState<string | null>(null);
+  const [seedError, setSeedError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [isSeeding, setIsSeeding] = useState(false);
+
+  const orderedFolders = useMemo(
+    () => folderOptions.filter((folder) => folder.exists),
+    [folderOptions]
+  );
+
+  useEffect(() => {
+    if (folderOptions.length === 0 || selectedFolders.size > 0) return;
+    setSelectedFolders(
+      new Set(folderOptions.filter((f) => f.defaultSelected && f.exists).map((f) => f.id))
+    );
+  }, [folderOptions, selectedFolders.size]);
 
   const toggleFolder = (id: string) => {
     setSelectedFolders((prev) => {
@@ -44,10 +65,25 @@ export const FolderSelection = ({ onNext }: FolderSelectionProps) => {
     });
   };
 
-  const handleScan = () => {
+  const handleScan = async () => {
     if (selectedFolders.size === 0) return;
+    setImportError(null);
     setIsScanning(true);
     setScanProgress(0);
+    const folderIds = Array.from(selectedFolders);
+
+    try {
+      await onImport(folderIds);
+      setScanProgress(100);
+      setTimeout(onNext, 500);
+    } catch (err) {
+      setIsScanning(false);
+      if (err instanceof Error) {
+        setImportError(err.message);
+      } else {
+        setImportError("Import fehlgeschlagen.");
+      }
+    }
   };
 
   // Simulate scanning animation
@@ -64,7 +100,6 @@ export const FolderSelection = ({ onNext }: FolderSelectionProps) => {
       if (progress >= 100) {
         progress = 100;
         clearInterval(interval);
-        setTimeout(onNext, 500);
       }
       
       setScanProgress(Math.min(progress, 100));
@@ -83,7 +118,29 @@ export const FolderSelection = ({ onNext }: FolderSelectionProps) => {
     if (firstFolder) setCurrentScanFolder(firstFolder.name);
 
     return () => clearInterval(interval);
-  }, [isScanning, selectedFolders, onNext]);
+  }, [isScanning, selectedFolders, folderOptions]);
+
+  const handleSeedDemo = async () => {
+    setSeedMessage(null);
+    setSeedError(null);
+    setIsSeeding(true);
+    try {
+      const seeded = await onSeedDemo();
+      setSeedMessage(`Demo-Dateien erstellt: ${seeded.demoRoot}`);
+      const demoFolder = seeded.folders.find((folder) => folder.isDemo);
+      if (demoFolder) {
+        setSelectedFolders((prev) => new Set([...prev, demoFolder.id]));
+      }
+    } catch (err) {
+      if (err instanceof Error) {
+        setSeedError(err.message);
+      } else {
+        setSeedError("Demo-Dateien konnten nicht erstellt werden.");
+      }
+    } finally {
+      setIsSeeding(false);
+    }
+  };
 
   if (isScanning) {
     return (
@@ -145,7 +202,9 @@ export const FolderSelection = ({ onNext }: FolderSelectionProps) => {
         
         {/* Folder grid */}
         <div className="grid grid-cols-2 gap-4 w-full mb-6">
-          {folderOptions.map((folder, index) => (
+          {orderedFolders.map((folder, index) => {
+            const Icon = iconMap[folder.id] ?? FolderPlus;
+            return (
             <GlassCard
               key={folder.id}
               delay={200 + index * 100}
@@ -164,12 +223,15 @@ export const FolderSelection = ({ onNext }: FolderSelectionProps) => {
                     "p-2 rounded-lg transition-colors duration-300",
                     selectedFolders.has(folder.id) ? "bg-primary/20" : "bg-muted"
                   )}>
-                    <folder.icon className={cn(
+                    <Icon className={cn(
                       "w-5 h-5 transition-colors duration-300",
                       selectedFolders.has(folder.id) ? "text-primary" : "text-muted-foreground"
                     )} />
                   </div>
-                  <span className="font-medium">{folder.name}</span>
+                  <div>
+                    <span className="font-medium">{folder.name}</span>
+                    <p className="text-xs text-muted-foreground/70">{folder.path}</p>
+                  </div>
                 </div>
                 <ToggleSwitch
                   checked={selectedFolders.has(folder.id)}
@@ -177,7 +239,8 @@ export const FolderSelection = ({ onNext }: FolderSelectionProps) => {
                 />
               </div>
             </GlassCard>
-          ))}
+            );
+          })}
           
           {/* Add more folders option */}
           <GlassCard
@@ -209,10 +272,35 @@ export const FolderSelection = ({ onNext }: FolderSelectionProps) => {
         >
           <AnimatedButton 
             onClick={handleScan}
-            disabled={selectedFolders.size === 0}
+            disabled={selectedFolders.size === 0 || isScanning}
           >
             Ausgewählte Ordner scannen
           </AnimatedButton>
+          {importError && (
+            <p className="mt-3 text-sm text-warning text-center">
+              {importError}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-4 flex flex-col items-center gap-2">
+          <AnimatedButton
+            onClick={handleSeedDemo}
+            disabled={isSeeding}
+            size="sm"
+            className="bg-secondary/30 hover:bg-secondary/50"
+          >
+            {isSeeding ? "Erstelle Demo-Dateien..." : "Demo-Dateien erstellen"}
+          </AnimatedButton>
+          {seedMessage && (
+            <p className="text-xs text-muted-foreground">{seedMessage}</p>
+          )}
+          {seedError && (
+            <p className="text-xs text-warning">{seedError}</p>
+          )}
+          {folderError && (
+            <p className="text-xs text-warning">{folderError}</p>
+          )}
         </div>
       </div>
     </div>

--- a/gui/src/components/onboarding/NodeGraph.tsx
+++ b/gui/src/components/onboarding/NodeGraph.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { mockViews, mockFiles, ViewNode, FileNode, getFilesInView } from "@/data/mockFileSystem";
+import type { ViewNode, FileNode } from "@/data/onboardingData";
 import { Clock, Folder, Grid, Download, Shield, X } from "lucide-react";
 import { AnimatedButton } from "./ui/AnimatedButton";
 
 interface NodeGraphProps {
   onNext: () => void;
   showTutorial?: boolean;
+  views: ViewNode[];
+  files: FileNode[];
 }
 
 const viewIcons: Record<string, typeof Clock> = {
@@ -45,7 +47,7 @@ interface TooltipData {
   position: { x: number; y: number };
 }
 
-export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
+export const NodeGraph = ({ onNext, showTutorial = true, views, files }: NodeGraphProps) => {
   const [animationPhase, setAnimationPhase] = useState(0);
   const [hoveredView, setHoveredView] = useState<string | null>(null);
   const [hoveredFile, setHoveredFile] = useState<string | null>(null);
@@ -71,10 +73,10 @@ export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
     if (animationPhase < 5 || !showTutorial) return;
     
     const showNextTooltip = () => {
-      if (tooltipIndex < mockViews.length) {
-        const view = mockViews[tooltipIndex];
+      if (tooltipIndex < views.length) {
+        const view = views[tooltipIndex];
         // Position tooltip near the view node
-        const angle = (tooltipIndex / mockViews.length) * Math.PI * 2 - Math.PI / 2;
+        const angle = (tooltipIndex / views.length) * Math.PI * 2 - Math.PI / 2;
         const radius = 180;
         setActiveTooltip({
           view,
@@ -83,14 +85,20 @@ export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
             y: Math.sin(angle) * radius,
           },
         });
-      } else if (tooltipIndex === mockViews.length) {
+      } else if (tooltipIndex === views.length) {
         setActiveTooltip(null);
         setShowInsight(true);
       }
     };
 
     showNextTooltip();
-  }, [animationPhase, tooltipIndex, showTutorial]);
+  }, [animationPhase, tooltipIndex, showTutorial, views]);
+
+  useEffect(() => {
+    setTooltipIndex(0);
+    setActiveTooltip(null);
+    setShowInsight(false);
+  }, [views.length]);
 
   const advanceTooltip = useCallback(() => {
     setTooltipIndex((prev) => prev + 1);
@@ -98,6 +106,9 @@ export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
 
   // Calculate node positions in a circular layout
   const getViewPosition = (index: number, total: number) => {
+    if (total === 0) {
+      return { x: 0, y: 0 };
+    }
     const angle = (index / total) * Math.PI * 2 - Math.PI / 2;
     const radius = 180;
     return {
@@ -109,10 +120,10 @@ export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
   // Get file positions clustered around their primary view
   const getFilePosition = (file: FileNode, fileIndex: number) => {
     const primaryView = file.views[0];
-    const viewIndex = mockViews.findIndex((v) => v.id === primaryView);
+    const viewIndex = views.findIndex((v) => v.id === primaryView);
     if (viewIndex === -1) return { x: 0, y: 0 };
     
-    const viewPos = getViewPosition(viewIndex, mockViews.length);
+    const viewPos = getViewPosition(viewIndex, views.length);
     const offset = 50 + fileIndex * 5;
     const angle = (fileIndex * 0.8) + viewIndex;
     
@@ -123,7 +134,7 @@ export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
   };
 
   // Get files that appear in multiple views (for highlighting)
-  const multiViewFiles = mockFiles.filter((f) => f.views.length > 1);
+  const multiViewFiles = files.filter((f) => f.views.length > 1);
 
   return (
     <div 
@@ -147,8 +158,8 @@ export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
         
         <g transform={`translate(${containerRef.current?.clientWidth ? containerRef.current.clientWidth / 2 : 500}, ${containerRef.current?.clientHeight ? containerRef.current.clientHeight / 2 : 400})`}>
           {/* Connections from hub to views */}
-          {animationPhase >= 3 && mockViews.map((view, index) => {
-            const pos = getViewPosition(index, mockViews.length);
+          {animationPhase >= 3 && views.map((view, index) => {
+            const pos = getViewPosition(index, views.length);
             return (
               <line
                 key={`hub-${view.id}`}
@@ -177,14 +188,14 @@ export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
           {animationPhase >= 4 && hoveredFile && (
             <>
               {(() => {
-                const file = mockFiles.find((f) => f.id === hoveredFile);
+                const file = files.find((f) => f.id === hoveredFile);
                 if (!file) return null;
-                const filePos = getFilePosition(file, mockFiles.indexOf(file));
+                const filePos = getFilePosition(file, files.indexOf(file));
                 
                 return file.views.map((viewId) => {
-                  const viewIndex = mockViews.findIndex((v) => v.id === viewId);
+                  const viewIndex = views.findIndex((v) => v.id === viewId);
                   if (viewIndex === -1) return null;
-                  const viewPos = getViewPosition(viewIndex, mockViews.length);
+                  const viewPos = getViewPosition(viewIndex, views.length);
                   
                   return (
                     <line
@@ -230,8 +241,8 @@ export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
         </div>
         
         {/* View nodes */}
-        {mockViews.map((view, index) => {
-          const pos = getViewPosition(index, mockViews.length);
+        {views.map((view, index) => {
+          const pos = getViewPosition(index, views.length);
           const Icon = viewIcons[view.icon] || Folder;
           const colors = colorClasses[view.color];
           
@@ -366,6 +377,17 @@ export const NodeGraph = ({ onNext, showTutorial = true }: NodeGraphProps) => {
       {!showTutorial && animationPhase >= 4 && (
         <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-30">
           <AnimatedButton onClick={onNext} size="md">
+            Weiter
+          </AnimatedButton>
+        </div>
+      )}
+
+      {views.length === 0 && (
+        <div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-30 glass-strong rounded-xl px-6 py-4 text-center">
+          <p className="text-sm text-muted-foreground mb-3">
+            Noch keine Daten importiert. Importiere Ordner, um dein Lattice zu sehen.
+          </p>
+          <AnimatedButton onClick={onNext} size="sm">
             Weiter
           </AnimatedButton>
         </div>

--- a/gui/src/components/onboarding/OnboardingContainer.tsx
+++ b/gui/src/components/onboarding/OnboardingContainer.tsx
@@ -1,10 +1,18 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { WelcomeScreen } from "./WelcomeScreen";
 import { FolderSelection } from "./FolderSelection";
 import { NodeGraph } from "./NodeGraph";
 import { SecurityCalibration } from "./SecurityCalibration";
 import { AhaTutorial } from "./AhaTutorial";
+import {
+  fetchFolderOptions,
+  importFolders,
+  initRepo,
+  seedDemoFiles,
+  type FolderOption,
+} from "@/lib/latticeApi";
+import { useOnboardingData } from "@/hooks/use-onboarding-data";
 
 export type OnboardingStage = 1 | 2 | 3 | 4 | 5 | "complete";
 
@@ -15,6 +23,9 @@ interface OnboardingContainerProps {
 export const OnboardingContainer = ({ onComplete }: OnboardingContainerProps) => {
   const [stage, setStage] = useState<OnboardingStage>(1);
   const [isTransitioning, setIsTransitioning] = useState(false);
+  const [folderOptions, setFolderOptions] = useState<FolderOption[]>([]);
+  const [folderError, setFolderError] = useState<string | null>(null);
+  const { data, refresh, assignToProject, settings, updateSecuritySettings } = useOnboardingData();
 
   const transitionToStage = useCallback((nextStage: OnboardingStage) => {
     setIsTransitioning(true);
@@ -31,18 +42,76 @@ export const OnboardingContainer = ({ onComplete }: OnboardingContainerProps) =>
     onComplete?.();
   }, [onComplete, transitionToStage]);
 
+  useEffect(() => {
+    const loadFolders = async () => {
+      try {
+        const options = await fetchFolderOptions();
+        setFolderOptions(options);
+      } catch (err) {
+        if (err instanceof Error) {
+          setFolderError(err.message);
+        } else {
+          setFolderError("Ordner konnten nicht geladen werden.");
+        }
+      }
+    };
+    void loadFolders();
+  }, []);
+
   const renderStage = () => {
     switch (stage) {
       case 1:
-        return <WelcomeScreen onNext={() => transitionToStage(2)} />;
+        return (
+          <WelcomeScreen
+            onNext={() => transitionToStage(2)}
+            onInitialize={initRepo}
+          />
+        );
       case 2:
-        return <FolderSelection onNext={() => transitionToStage(3)} />;
+        return (
+          <FolderSelection
+            onNext={() => {
+              transitionToStage(3);
+              void refresh();
+            }}
+            folderOptions={folderOptions}
+            folderError={folderError}
+            onImport={importFolders}
+            onSeedDemo={async () => {
+              const seeded = await seedDemoFiles();
+              setFolderOptions(seeded.folders);
+              return seeded;
+            }}
+          />
+        );
       case 3:
-        return <NodeGraph onNext={() => transitionToStage(4)} showTutorial />;
+        return (
+          <NodeGraph
+            onNext={() => transitionToStage(4)}
+            showTutorial
+            files={data?.files ?? []}
+            views={data?.views ?? []}
+          />
+        );
       case 4:
-        return <SecurityCalibration onNext={() => transitionToStage(5)} />;
+        return (
+          <SecurityCalibration
+            onNext={() => transitionToStage(5)}
+            settings={settings}
+            onUpdateSettings={updateSecuritySettings}
+          />
+        );
       case 5:
-        return <AhaTutorial onComplete={handleComplete} />;
+        return (
+          <AhaTutorial
+            onComplete={handleComplete}
+            files={data?.files ?? []}
+            views={data?.views ?? []}
+            projects={data?.projects ?? []}
+            highlightedFileId={data?.highlightedFileId ?? null}
+            onAssignProject={assignToProject}
+          />
+        );
       case "complete":
         return (
           <div className="flex items-center justify-center min-h-screen">

--- a/gui/src/components/onboarding/SecurityCalibration.tsx
+++ b/gui/src/components/onboarding/SecurityCalibration.tsx
@@ -5,9 +5,12 @@ import { ToggleSwitch } from "./ui/ToggleSwitch";
 import { ParticleBackground } from "./ui/ParticleBackground";
 import { cn } from "@/lib/utils";
 import { Shield, Download, History, AlertTriangle, Check } from "lucide-react";
+import type { OnboardingSettings } from "@/lib/latticeApi";
 
 interface SecurityCalibrationProps {
   onNext: () => void;
+  settings: OnboardingSettings | null;
+  onUpdateSettings: (next: OnboardingSettings) => Promise<void>;
 }
 
 interface SecurityOption {
@@ -42,10 +45,12 @@ const securityOptions: SecurityOption[] = [
   },
 ];
 
-export const SecurityCalibration = ({ onNext }: SecurityCalibrationProps) => {
-  const [settings, setSettings] = useState<Record<string, boolean>>(
+export const SecurityCalibration = ({ onNext, settings, onUpdateSettings }: SecurityCalibrationProps) => {
+  const [localSettings, setLocalSettings] = useState<Record<string, boolean>>(
     Object.fromEntries(securityOptions.map((opt) => [opt.id, opt.defaultEnabled]))
   );
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [isAnimatingOut, setIsAnimatingOut] = useState(false);
   const [showShield, setShowShield] = useState(false);
 
@@ -54,16 +59,42 @@ export const SecurityCalibration = ({ onNext }: SecurityCalibrationProps) => {
     return () => clearTimeout(timer);
   }, []);
 
+  useEffect(() => {
+    if (!settings) return;
+    setLocalSettings({
+      quarantine: settings.quarantineDownloads,
+      versioning: settings.versioning,
+      "execute-warning": settings.executeWarning,
+    });
+  }, [settings]);
+
   const toggleSetting = (id: string) => {
-    setSettings((prev) => ({
+    setLocalSettings((prev) => ({
       ...prev,
       [id]: !prev[id],
     }));
   };
 
-  const handleProceed = () => {
-    setIsAnimatingOut(true);
-    setTimeout(onNext, 800);
+  const handleProceed = async () => {
+    setIsSaving(true);
+    setError(null);
+    try {
+      await onUpdateSettings({
+        quarantineDownloads: localSettings.quarantine,
+        versioning: localSettings.versioning,
+        executeWarning: localSettings["execute-warning"],
+      });
+      setIsAnimatingOut(true);
+      setTimeout(onNext, 800);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Einstellungen konnten nicht gespeichert werden.");
+      }
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
@@ -138,11 +169,11 @@ export const SecurityCalibration = ({ onNext }: SecurityCalibrationProps) => {
               <div className="flex items-start gap-4">
                 <div className={cn(
                   "flex-shrink-0 p-3 rounded-xl transition-colors duration-300",
-                  settings[option.id] ? "bg-primary/20" : "bg-muted"
+                  localSettings[option.id] ? "bg-primary/20" : "bg-muted"
                 )}>
                   <option.icon className={cn(
                     "w-5 h-5 transition-colors duration-300",
-                    settings[option.id] ? "text-primary" : "text-muted-foreground"
+                    localSettings[option.id] ? "text-primary" : "text-muted-foreground"
                   )} />
                 </div>
                 
@@ -152,13 +183,13 @@ export const SecurityCalibration = ({ onNext }: SecurityCalibrationProps) => {
                       {option.title}
                     </h4>
                     <ToggleSwitch
-                      checked={settings[option.id]}
+                      checked={localSettings[option.id]}
                       onChange={() => toggleSetting(option.id)}
                     />
                   </div>
                   <p className={cn(
                     "text-sm transition-all duration-300 overflow-hidden",
-                    settings[option.id] 
+                    localSettings[option.id] 
                       ? "text-muted-foreground max-h-20 opacity-100" 
                       : "text-muted-foreground/50 max-h-0 opacity-0"
                   )}>
@@ -183,9 +214,14 @@ export const SecurityCalibration = ({ onNext }: SecurityCalibrationProps) => {
           className="opacity-0 animate-fade-up"
           style={{ animationDelay: "950ms", animationFillMode: "forwards" }}
         >
-          <AnimatedButton onClick={handleProceed}>
-            Sieht gut aus
+          <AnimatedButton onClick={handleProceed} disabled={isSaving}>
+            {isSaving ? "Speichere..." : "Sieht gut aus"}
           </AnimatedButton>
+          {error && (
+            <p className="mt-3 text-sm text-warning text-center">
+              {error}
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/gui/src/components/onboarding/WelcomeScreen.tsx
+++ b/gui/src/components/onboarding/WelcomeScreen.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 
 interface WelcomeScreenProps {
   onNext: () => void;
+  onInitialize: () => Promise<{ repoPath: string; version: string }>;
 }
 
 const philosophyCards = [
@@ -28,13 +29,28 @@ const philosophyCards = [
   },
 ];
 
-export const WelcomeScreen = ({ onNext }: WelcomeScreenProps) => {
+export const WelcomeScreen = ({ onNext, onInitialize }: WelcomeScreenProps) => {
   const [isTransitioning, setIsTransitioning] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleCreateLattice = () => {
-    setIsTransitioning(true);
-    // Allow animation to play before transitioning
-    setTimeout(onNext, 800);
+  const handleCreateLattice = async () => {
+    setError(null);
+    setIsInitializing(true);
+    try {
+      await onInitialize();
+      setIsTransitioning(true);
+      // Allow animation to play before transitioning
+      setTimeout(onNext, 800);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Lattice konnte nicht initialisiert werden.");
+      }
+    } finally {
+      setIsInitializing(false);
+    }
   };
 
   return (
@@ -106,9 +122,14 @@ export const WelcomeScreen = ({ onNext }: WelcomeScreenProps) => {
           className="opacity-0 animate-fade-up"
           style={{ animationDelay: "1400ms", animationFillMode: "forwards" }}
         >
-          <AnimatedButton onClick={handleCreateLattice}>
-            Create My Lattice
+          <AnimatedButton onClick={handleCreateLattice} disabled={isInitializing}>
+            {isInitializing ? "Initialisiere..." : "Create My Lattice"}
           </AnimatedButton>
+          {error && (
+            <p className="mt-3 text-sm text-warning text-center">
+              {error}
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/gui/src/data/onboardingData.ts
+++ b/gui/src/data/onboardingData.ts
@@ -1,0 +1,43 @@
+import type { OnboardingData, OnboardingFile, OnboardingProject, OnboardingView } from "@/lib/latticeApi";
+
+export type ViewNode = OnboardingView;
+
+export type FileNode = {
+  id: string;
+  name: string;
+  extension?: string;
+  size: number;
+  createdAt: Date;
+  tags: string[];
+  views: string[];
+};
+
+export type ProjectNode = OnboardingProject;
+
+export type OnboardingState = {
+  views: ViewNode[];
+  files: FileNode[];
+  projects: ProjectNode[];
+  highlightedFileId: string | null;
+};
+
+export const mapOnboardingData = (data: OnboardingData): OnboardingState => ({
+  views: data.views,
+  files: data.files.map((file) => ({
+    id: file.id,
+    name: file.name,
+    extension: file.extension ?? undefined,
+    size: file.sizeBytes,
+    createdAt: new Date(file.createdAt),
+    tags: file.tags,
+    views: file.views,
+  })),
+  projects: data.projects,
+  highlightedFileId: data.highlightedFileId,
+});
+
+export const getFilesInView = (files: FileNode[], viewId: string): FileNode[] =>
+  files.filter((file) => file.views.includes(viewId));
+
+export const getFileById = (files: FileNode[], fileId: string): FileNode | undefined =>
+  files.find((file) => file.id === fileId);

--- a/gui/src/hooks/use-onboarding-data.ts
+++ b/gui/src/hooks/use-onboarding-data.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  assignProject,
+  fetchOnboardingData,
+  fetchSettings,
+  updateSettings,
+  type OnboardingSettings,
+} from "@/lib/latticeApi";
+import { mapOnboardingData, type OnboardingState } from "@/data/onboardingData";
+
+type UseOnboardingData = {
+  data: OnboardingState | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  assignToProject: (objectId: string, projectId: string) => Promise<void>;
+  settings: OnboardingSettings | null;
+  updateSecuritySettings: (next: OnboardingSettings) => Promise<void>;
+};
+
+export const useOnboardingData = (): UseOnboardingData => {
+  const [data, setData] = useState<OnboardingState | null>(null);
+  const [settings, setSettings] = useState<OnboardingSettings | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [onboarding, storedSettings] = await Promise.all([
+        fetchOnboardingData(),
+        fetchSettings(),
+      ]);
+      setData(mapOnboardingData(onboarding));
+      setSettings(storedSettings);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Onboarding-Daten konnten nicht geladen werden.");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const assignToProject = useCallback(async (objectId: string, projectId: string) => {
+    setError(null);
+    try {
+      const updated = await assignProject(objectId, projectId);
+      setData(mapOnboardingData(updated));
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Projekt konnte nicht zugewiesen werden.");
+      }
+    }
+  }, []);
+
+  const updateSecuritySettings = useCallback(async (next: OnboardingSettings) => {
+    setError(null);
+    try {
+      const updated = await updateSettings(next);
+      setSettings(updated);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Einstellungen konnten nicht gespeichert werden.");
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { data, isLoading, error, refresh, assignToProject, settings, updateSecuritySettings };
+};

--- a/gui/src/lib/latticeApi.ts
+++ b/gui/src/lib/latticeApi.ts
@@ -1,0 +1,327 @@
+export type FolderOption = {
+  id: string;
+  name: string;
+  path: string;
+  exists: boolean;
+  defaultSelected: boolean;
+  isDemo: boolean;
+};
+
+export type OnboardingSettings = {
+  quarantineDownloads: boolean;
+  versioning: boolean;
+  executeWarning: boolean;
+};
+
+export type OnboardingView = {
+  id: string;
+  name: string;
+  icon: "Clock" | "Folder" | "Grid" | "Download" | "Shield";
+  description: string;
+  color: "primary" | "secondary" | "warning" | "muted";
+};
+
+export type OnboardingFile = {
+  id: string;
+  name: string;
+  extension: string | null;
+  sizeBytes: number;
+  createdAt: string;
+  tags: string[];
+  views: string[];
+};
+
+export type OnboardingProject = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+export type OnboardingData = {
+  views: OnboardingView[];
+  files: OnboardingFile[];
+  projects: OnboardingProject[];
+  highlightedFileId: string | null;
+};
+
+export type ImportSummary = {
+  folderId: string;
+  files: number;
+  objects: number;
+  bytes: number;
+  errors: string[];
+};
+
+export type ImportResponse = {
+  summaries: ImportSummary[];
+  totalFiles: number;
+  totalObjects: number;
+  totalBytes: number;
+  errors: string[];
+};
+
+const API_BASE = import.meta.env.VITE_LFS_GUI_API ?? "http://localhost:8788";
+
+const toFolderOption = (option: {
+  id: string;
+  name: string;
+  path: string;
+  exists: boolean;
+  default_selected: boolean;
+  is_demo: boolean;
+}): FolderOption => ({
+  id: option.id,
+  name: option.name,
+  path: option.path,
+  exists: option.exists,
+  defaultSelected: option.default_selected,
+  isDemo: option.is_demo,
+});
+
+const toSettings = (settings: {
+  quarantine_downloads: boolean;
+  versioning: boolean;
+  execute_warning: boolean;
+}): OnboardingSettings => ({
+  quarantineDownloads: settings.quarantine_downloads,
+  versioning: settings.versioning,
+  executeWarning: settings.execute_warning,
+});
+
+const toImportSummary = (summary: {
+  folder_id: string;
+  files: number;
+  objects: number;
+  bytes: number;
+  errors: string[];
+}): ImportSummary => ({
+  folderId: summary.folder_id,
+  files: summary.files,
+  objects: summary.objects,
+  bytes: summary.bytes,
+  errors: summary.errors,
+});
+
+const toImportResponse = (data: {
+  summaries: {
+    folder_id: string;
+    files: number;
+    objects: number;
+    bytes: number;
+    errors: string[];
+  }[];
+  total_files: number;
+  total_objects: number;
+  total_bytes: number;
+  errors: string[];
+}): ImportResponse => ({
+  summaries: data.summaries.map(toImportSummary),
+  totalFiles: data.total_files,
+  totalObjects: data.total_objects,
+  totalBytes: data.total_bytes,
+  errors: data.errors,
+});
+
+const toOnboardingView = (view: {
+  id: string;
+  name: string;
+  icon: "Clock" | "Folder" | "Grid" | "Download" | "Shield";
+  description: string;
+  color: "primary" | "secondary" | "warning" | "muted";
+}): OnboardingView => view;
+
+const toOnboardingFile = (file: {
+  id: string;
+  name: string;
+  extension: string | null;
+  size_bytes: number;
+  created_at: string;
+  tags: string[];
+  views: string[];
+}): OnboardingFile => ({
+  id: file.id,
+  name: file.name,
+  extension: file.extension,
+  sizeBytes: file.size_bytes,
+  createdAt: file.created_at,
+  tags: file.tags,
+  views: file.views,
+});
+
+const toOnboardingProject = (project: {
+  id: string;
+  name: string;
+  color: string;
+}): OnboardingProject => project;
+
+export const initRepo = async (): Promise<{ repoPath: string; version: string }> => {
+  const response = await fetch(`${API_BASE}/api/onboarding/init`, { method: "POST" });
+  if (!response.ok) {
+    throw new Error("Repo konnte nicht initialisiert werden.");
+  }
+  const data = (await response.json()) as { repo_path: string; version: string };
+  return { repoPath: data.repo_path, version: data.version };
+};
+
+export const fetchFolderOptions = async (): Promise<FolderOption[]> => {
+  const response = await fetch(`${API_BASE}/api/onboarding/folders`);
+  if (!response.ok) {
+    throw new Error("Ordner konnten nicht geladen werden.");
+  }
+  const data = (await response.json()) as {
+    id: string;
+    name: string;
+    path: string;
+    exists: boolean;
+    default_selected: boolean;
+    is_demo: boolean;
+  }[];
+  return data.map(toFolderOption);
+};
+
+export const seedDemoFiles = async (): Promise<{ demoRoot: string; folders: FolderOption[] }> => {
+  const response = await fetch(`${API_BASE}/api/onboarding/seed-files`, { method: "POST" });
+  if (!response.ok) {
+    throw new Error("Demo-Dateien konnten nicht erstellt werden.");
+  }
+  const data = (await response.json()) as {
+    demo_root: string;
+    folders: {
+      id: string;
+      name: string;
+      path: string;
+      exists: boolean;
+      default_selected: boolean;
+      is_demo: boolean;
+    }[];
+  };
+  return { demoRoot: data.demo_root, folders: data.folders.map(toFolderOption) };
+};
+
+export const importFolders = async (folderIds: string[]): Promise<ImportResponse> => {
+  const response = await fetch(`${API_BASE}/api/onboarding/import`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ folder_ids: folderIds }),
+  });
+  if (!response.ok) {
+    throw new Error("Import fehlgeschlagen.");
+  }
+  const data = (await response.json()) as {
+    summaries: {
+      folder_id: string;
+      files: number;
+      objects: number;
+      bytes: number;
+      errors: string[];
+    }[];
+    total_files: number;
+    total_objects: number;
+    total_bytes: number;
+    errors: string[];
+  };
+  return toImportResponse(data);
+};
+
+export const fetchOnboardingData = async (): Promise<OnboardingData> => {
+  const response = await fetch(`${API_BASE}/api/onboarding/data`);
+  if (!response.ok) {
+    throw new Error("Onboarding-Daten konnten nicht geladen werden.");
+  }
+  const data = (await response.json()) as {
+    views: {
+      id: string;
+      name: string;
+      icon: "Clock" | "Folder" | "Grid" | "Download" | "Shield";
+      description: string;
+      color: "primary" | "secondary" | "warning" | "muted";
+    }[];
+    files: {
+      id: string;
+      name: string;
+      extension: string | null;
+      size_bytes: number;
+      created_at: string;
+      tags: string[];
+      views: string[];
+    }[];
+    projects: { id: string; name: string; color: string }[];
+    highlighted_file_id: string | null;
+  };
+  return {
+    views: data.views.map(toOnboardingView),
+    files: data.files.map(toOnboardingFile),
+    projects: data.projects.map(toOnboardingProject),
+    highlightedFileId: data.highlighted_file_id,
+  };
+};
+
+export const fetchSettings = async (): Promise<OnboardingSettings> => {
+  const response = await fetch(`${API_BASE}/api/onboarding/settings`);
+  if (!response.ok) {
+    throw new Error("Einstellungen konnten nicht geladen werden.");
+  }
+  const data = (await response.json()) as {
+    settings: { quarantine_downloads: boolean; versioning: boolean; execute_warning: boolean };
+  };
+  return toSettings(data.settings);
+};
+
+export const updateSettings = async (settings: OnboardingSettings): Promise<OnboardingSettings> => {
+  const response = await fetch(`${API_BASE}/api/onboarding/settings`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      quarantine_downloads: settings.quarantineDownloads,
+      versioning: settings.versioning,
+      execute_warning: settings.executeWarning,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error("Einstellungen konnten nicht gespeichert werden.");
+  }
+  const data = (await response.json()) as {
+    settings: { quarantine_downloads: boolean; versioning: boolean; execute_warning: boolean };
+  };
+  return toSettings(data.settings);
+};
+
+export const assignProject = async (
+  objectId: string,
+  projectId: string,
+): Promise<OnboardingData> => {
+  const response = await fetch(`${API_BASE}/api/onboarding/assign-project`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ object_id: objectId, project_id: projectId }),
+  });
+  if (!response.ok) {
+    throw new Error("Projekt konnte nicht zugewiesen werden.");
+  }
+  const data = (await response.json()) as {
+    views: {
+      id: string;
+      name: string;
+      icon: "Clock" | "Folder" | "Grid" | "Download" | "Shield";
+      description: string;
+      color: "primary" | "secondary" | "warning" | "muted";
+    }[];
+    files: {
+      id: string;
+      name: string;
+      extension: string | null;
+      size_bytes: number;
+      created_at: string;
+      tags: string[];
+      views: string[];
+    }[];
+    projects: { id: string; name: string; color: string }[];
+    highlighted_file_id: string | null;
+  };
+  return {
+    views: data.views.map(toOnboardingView),
+    files: data.files.map(toOnboardingFile),
+    projects: data.projects.map(toOnboardingProject),
+    highlightedFileId: data.highlighted_file_id,
+  };
+};


### PR DESCRIPTION
### Motivation
- Connect the GUI onboarding flow to the actual LatticeFS logic so users can initialize a repo, import real files and persist security settings instead of showing static mock UI. 
- Provide a simple local HTTP bridge for the GUI to call into repository/import code without redesigning the core daemon yet. 
- Add a developer/demo helper to seed example files so imports can be exercised during development and demos.

### Description
- Add a lightweight GUI API binary `lfs-gui` (`cli/src/bin/lfs-gui.rs`) exposing endpoints: `POST /api/onboarding/init`, `GET /api/onboarding/folders`, `POST /api/onboarding/seed-files`, `POST /api/onboarding/import`, `GET|POST /api/onboarding/settings`, `GET /api/onboarding/data` and `POST /api/onboarding/assign-project`; it uses the existing `LatticeRepo` import helpers and stores GUI settings under the repo home. 
- Update CLI crate deps (`cli/Cargo.toml`) to include HTTP server deps (`axum`, `tower-http`, `humantime`, `serde_json`) and add `cli/src/lib.rs` module shim to expose commands for the binary. 
- Add frontend API client `gui/src/lib/latticeApi.ts` plus typed onboarding mapping `gui/src/data/onboardingData.ts` and a React hook `gui/src/hooks/use-onboarding-data.ts` to fetch onboarding state, settings, import, seed demo files and assign projects. 
- Wire onboarding components to real logic: `OnboardingContainer`, `WelcomeScreen`, `FolderSelection`, `NodeGraph`, `SecurityCalibration`, and `AhaTutorial` now call the API (init, list folders, import, seed demo, persist settings, assign projects) and render real onboarding data instead of mocks; a developer-only “Demo-Dateien erstellen” button was added to the folder selection step to create sample files for imports. 
- Import flow tags objects post-import (folder/inbox/project/risk/sys:trust) to make views and tutorial highlights meaningful; onboarding data aggregates views/files/projects for the GUI.

### Testing
- Ran GUI unit tests with `bun run test` (Vitest) which passed (`1 test` passed). 
- Ran full Rust test-suite with `cargo test` for the workspace which passed (all unit tests and property tests succeeded). 
- Built the CLI package with `cargo build -p cli` which completed successfully and `cargo run --bin lfs-gui` started the local API listener for manual verification. 
- Executed a headless browser smoke (Playwright) to exercise the onboarding flow and capture a screenshot of the folder selection screen after clicking the welcome CTA (screenshot artifact produced during the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983d6dad65c8321b788cb4a85fb6006)