### PR TITLE
fix(cli): store auto-loaded repo in project-local .latticefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,5 @@ dist/
 build/
 node_modules/
 latticedemosurface/
+.latticefs/
+.latticefs.toml

--- a/cli/src/commands/common.rs
+++ b/cli/src/commands/common.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const LOCAL_REPO_CONFIG_FILE: &str = ".latticefs.toml";
+const LOCAL_REPO_DIR: &str = ".latticefs";
 
 #[derive(Debug, Deserialize)]
 struct LocalRepoConfig {
@@ -35,7 +36,7 @@ fn resolve_repo_override(repo_path: Option<PathBuf>, cwd: &Path) -> Result<Optio
     }
 
     if should_auto_load_repo(cwd)? {
-        return Ok(Some(cwd.to_path_buf()));
+        return Ok(Some(cwd.join(LOCAL_REPO_DIR)));
     }
 
     Ok(None)
@@ -290,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn marker_auto_load_sets_repo_to_cwd() {
+    fn marker_auto_load_sets_repo_to_local_repo_dir() {
         let cwd = TempDir::new().unwrap();
         fs::write(
             cwd.path().join(LOCAL_REPO_CONFIG_FILE),
@@ -299,7 +300,7 @@ mod tests {
         .unwrap();
 
         let resolved = resolve_repo_override(None, cwd.path()).unwrap();
-        assert_eq!(resolved, Some(cwd.path().to_path_buf()));
+        assert_eq!(resolved, Some(cwd.path().join(LOCAL_REPO_DIR)));
     }
 
     #[test]

--- a/cli/tests/repo_autoload.rs
+++ b/cli/tests/repo_autoload.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 const LOCAL_REPO_CONFIG_FILE: &str = ".latticefs.toml";
+const LOCAL_REPO_DIR: &str = ".latticefs";
 
 fn lfs_cmd(lattice_home: &PathBuf, xdg_home: &PathBuf) -> Command {
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("lfs"));
@@ -35,9 +36,9 @@ fn auto_loads_repo_from_current_directory_marker() {
         .assert()
         .success();
 
-    assert!(workspace.join("meta").is_dir());
-    assert!(workspace.join("chunks").is_dir());
-    assert!(workspace.join("logs").is_dir());
+    assert!(workspace.join(LOCAL_REPO_DIR).join("meta").is_dir());
+    assert!(workspace.join(LOCAL_REPO_DIR).join("chunks").is_dir());
+    assert!(workspace.join(LOCAL_REPO_DIR).join("logs").is_dir());
     assert!(!lattice_home.join("meta").exists());
 }
 
@@ -66,7 +67,7 @@ fn explicit_repo_flag_overrides_auto_load_marker() {
 
     assert!(explicit_repo.join("meta").is_dir());
     assert!(explicit_repo.join("chunks").is_dir());
-    assert!(!workspace.join("meta").exists());
+    assert!(!workspace.join(LOCAL_REPO_DIR).join("meta").exists());
 }
 
 #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ Examples throughout this document show English output, but German systems will s
 - `-v`, `-vv` — increase verbosity
 - `--repo <path>` — override repository root
 - `--fuse` — enable FUSE operations (required for `mount`)
-- If `--repo` is omitted and the current directory contains `.latticefs.toml` with `repo.auto_load = true`, the CLI uses the current directory as the repo root.
+- If `--repo` is omitted and the current directory contains `.latticefs.toml` with `repo.auto_load = true`, the CLI uses `.latticefs/` under the current directory as the repo root.
 
 Example:
 ```bash
@@ -40,7 +40,7 @@ cat > .latticefs.toml <<'EOF'
 auto_load = true
 EOF
 
-# Uses current directory as repo root (same as: lfs --repo "$PWD" status)
+# Uses .latticefs under current directory as repo root (same as: lfs --repo "$PWD/.latticefs" status)
 lfs status
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,23 +1,26 @@
 # Configuration
 
 Default config path:
+
 ```
 ~/.latticefs/config.toml
 ```
 
 You can override the repo root with:
+
 ```
 LATTICE_HOME=/path/to/repo lfs <command>
 ```
 
 You can also override by command:
+
 ```
 lfs --repo /path/to/repo <command>
 ```
 
 ## Per-directory auto-load
 
-If you run `lfs` from a project directory and want that directory to be used as the repo root (without typing `--repo`), create `.latticefs.toml` in that directory:
+If you run `lfs` from a project directory and want a project-local repo (without typing `--repo`), create `.latticefs.toml` in that directory:
 
 ```toml
 [repo]
@@ -26,10 +29,12 @@ auto_load = true
 
 Behavior:
 - Precedence is `--repo` (highest), then `.latticefs.toml` auto-load, then global config/default (`~/.latticefs` or `LATTICE_HOME`).
+- When auto-load is enabled, the repo root is `<cwd>/.latticefs`
 - Only the current working directory is checked for `.latticefs.toml`.
 - Any value other than `repo.auto_load = true` disables auto-load.
 
 ## Schema
+
 ```toml
 [storage]
 path = "~/.latticefs"


### PR DESCRIPTION
## Summary
- add per-directory auto-load support via `.latticefs.toml` (`repo.auto_load = true`)
- resolve auto-loaded repo root to `<cwd>/.latticefs` so repository data does not pollute the project root
- keep `--repo` precedence above auto-load and default global config fallback
- add/adjust CLI unit + integration tests for marker parsing, precedence, and repo directory placement
- update CLI and config docs with the new auto-load behavior and examples

## Why
The previous auto-load path could write metadata/chunks directly into the project directory. This change makes auto-load safer and cleaner by isolating repo internals under a dedicated hidden subdirectory.

## Testing
- `cargo test -p cli marker_auto_load_sets_repo_to_local_repo_dir -- --nocapture`
- `cargo test -p cli --test repo_autoload -- --nocapture`

## Notes
- `.gitignore` now includes `.latticefs` and `.latticefs.toml`.
- Existing explicit repo usage (`--repo`) is unchanged.
