### PR TITLE
Rename CLI `stats` command to `info` (code, docs, tests)

### DIFF
--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -14,20 +14,20 @@ use super::common::{
 };
 
 #[derive(Subcommand, Debug)]
-pub enum StatsCommand {
+pub enum InfoCommand {
     /// Show content checksum for an object (alias: hash)
     #[command(alias = "hash")]
-    Checksum(StatsChecksumArgs),
+    Checksum(InfoChecksumArgs),
     /// Show object statistics
-    Object(StatsObjectArgs),
+    Object(InfoObjectArgs),
     /// Show statistics for a single view
-    View(StatsViewArgs),
+    View(InfoViewArgs),
     /// List objects for a view with minimal tag output
-    ViewObjects(StatsViewObjectsArgs),
+    ViewObjects(InfoViewObjectsArgs),
     /// Summarize all views
     Views,
     /// Show statistics for a single policy
-    Policy(StatsPolicyArgs),
+    Policy(InfoPolicyArgs),
     /// Summarize all policies
     Policies,
     /// Summarize shared capabilities
@@ -35,19 +35,19 @@ pub enum StatsCommand {
 }
 
 #[derive(Args, Debug)]
-pub struct StatsArgs {
+pub struct InfoArgs {
     #[command(subcommand)]
-    pub command: StatsCommand,
+    pub command: InfoCommand,
 }
 
 #[derive(Args, Debug)]
-pub struct StatsChecksumArgs {
+pub struct InfoChecksumArgs {
     /// Object reference (optionally @version)
     pub reference: String,
 }
 
 #[derive(Args, Debug)]
-pub struct StatsObjectArgs {
+pub struct InfoObjectArgs {
     /// Object reference
     pub reference: String,
     /// Include per-version stats
@@ -56,13 +56,13 @@ pub struct StatsObjectArgs {
 }
 
 #[derive(Args, Debug)]
-pub struct StatsViewArgs {
+pub struct InfoViewArgs {
     /// View name or ID (builtin or dynamic)
     pub name: String,
 }
 
 #[derive(Args, Debug)]
-pub struct StatsViewObjectsArgs {
+pub struct InfoViewObjectsArgs {
     /// View name or ID (builtin or dynamic)
     pub name: String,
     /// Include auto/system tags
@@ -74,25 +74,25 @@ pub struct StatsViewObjectsArgs {
 }
 
 #[derive(Args, Debug)]
-pub struct StatsPolicyArgs {
+pub struct InfoPolicyArgs {
     /// Policy name
     pub name: String,
 }
 
-pub async fn run(repo: LatticeRepo, cmd: StatsCommand) -> Result<()> {
+pub async fn run(repo: LatticeRepo, cmd: InfoCommand) -> Result<()> {
     match cmd {
-        StatsCommand::Checksum(args) => checksum(repo, args).await,
-        StatsCommand::Object(args) => object_stats(repo, args).await,
-        StatsCommand::View(args) => view_stats(repo, args).await,
-        StatsCommand::ViewObjects(args) => view_objects(repo, args).await,
-        StatsCommand::Views => views_summary(repo).await,
-        StatsCommand::Policy(args) => policy_stats(repo, args).await,
-        StatsCommand::Policies => policies_summary(repo).await,
-        StatsCommand::Shares => shares_summary(repo).await,
+        InfoCommand::Checksum(args) => checksum(repo, args).await,
+        InfoCommand::Object(args) => object_stats(repo, args).await,
+        InfoCommand::View(args) => view_stats(repo, args).await,
+        InfoCommand::ViewObjects(args) => view_objects(repo, args).await,
+        InfoCommand::Views => views_summary(repo).await,
+        InfoCommand::Policy(args) => policy_stats(repo, args).await,
+        InfoCommand::Policies => policies_summary(repo).await,
+        InfoCommand::Shares => shares_summary(repo).await,
     }
 }
 
-async fn checksum(repo: LatticeRepo, args: StatsChecksumArgs) -> Result<()> {
+async fn checksum(repo: LatticeRepo, args: InfoChecksumArgs) -> Result<()> {
     let (object_id, version_id) = parse_ref_with_version(&repo, &args.reference)?;
     let object = repo
         .metadata
@@ -116,7 +116,7 @@ async fn checksum(repo: LatticeRepo, args: StatsChecksumArgs) -> Result<()> {
     Ok(())
 }
 
-async fn object_stats(repo: LatticeRepo, args: StatsObjectArgs) -> Result<()> {
+async fn object_stats(repo: LatticeRepo, args: InfoObjectArgs) -> Result<()> {
     let object_id = resolve_object_id(&repo, &args.reference)?;
     let object = repo
         .metadata
@@ -168,7 +168,7 @@ async fn object_stats(repo: LatticeRepo, args: StatsObjectArgs) -> Result<()> {
     Ok(())
 }
 
-async fn view_stats(repo: LatticeRepo, args: StatsViewArgs) -> Result<()> {
+async fn view_stats(repo: LatticeRepo, args: InfoViewArgs) -> Result<()> {
     let locale = Locale::from_system();
     match resolve_view_reference(&repo, &args.name)? {
         ResolvedView::Builtin(builtin) => {
@@ -212,7 +212,7 @@ async fn view_stats(repo: LatticeRepo, args: StatsViewArgs) -> Result<()> {
     Ok(())
 }
 
-async fn view_objects(repo: LatticeRepo, args: StatsViewObjectsArgs) -> Result<()> {
+async fn view_objects(repo: LatticeRepo, args: InfoViewObjectsArgs) -> Result<()> {
     let object_ids = match resolve_view_reference(&repo, &args.name)? {
         ResolvedView::Builtin(builtin) => {
             let builtins = BuiltinViews::new(&repo.metadata);
@@ -294,7 +294,7 @@ async fn views_summary(repo: LatticeRepo) -> Result<()> {
     Ok(())
 }
 
-async fn policy_stats(repo: LatticeRepo, args: StatsPolicyArgs) -> Result<()> {
+async fn policy_stats(repo: LatticeRepo, args: InfoPolicyArgs) -> Result<()> {
     let policy = repo.metadata.load_policy(&args.name)?;
     let mut object_count = 0usize;
     for object in repo.metadata.iter_objects() {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -19,7 +19,7 @@ pub mod revoke;
 pub mod share;
 pub mod shares;
 pub mod state;
-pub mod stats;
+pub mod info;
 pub mod system;
 pub mod tag;
 pub mod tags;
@@ -52,7 +52,7 @@ pub enum Command {
     Policy(policy::PolicyArgs),
     Trust(trust::TrustArgs),
     Quarantine(trust::QuarantineArgs),
-    Stats(stats::StatsArgs),
+    Info(info::InfoArgs),
     Import(import::ImportArgs),
     Export(export::ExportArgs),
     Edit(edit::EditArgs),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -135,9 +135,9 @@ async fn main() -> Result<()> {
             let repo = commands::common::open_repo(cli.repo.clone())?;
             commands::trust::quarantine(repo, cmd.command).await?;
         }
-        commands::Command::Stats(cmd) => {
+        commands::Command::Info(cmd) => {
             let repo = commands::common::open_repo(cli.repo.clone())?;
-            commands::stats::run(repo, cmd.command).await?;
+            commands::info::run(repo, cmd.command).await?;
         }
         commands::Command::Edit(args) => {
             let repo = commands::common::open_repo(cli.repo.clone())?;

--- a/cli/tests/cli_flow.rs
+++ b/cli/tests/cli_flow.rs
@@ -106,7 +106,7 @@ fn cli_flow_basic() {
         .success();
 
     lfs_cmd(&lattice_home, &xdg_home)
-        .args(["stats", "view", "ImageAuto"])
+        .args(["info", "view", "ImageAuto"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Objects: 1"));
@@ -399,7 +399,7 @@ fn cli_flow_nested_views() {
 
     // Verify nested view query works (should only match file1, not file2 or file3)
     lfs_cmd(&lattice_home, &xdg_home)
-        .args(["stats", "view", "PhoenixDocs"])
+        .args(["info", "view", "PhoenixDocs"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Parent: PhoenixProject"))

--- a/docs/cli-recipes.md
+++ b/docs/cli-recipes.md
@@ -125,13 +125,13 @@ lfs meta <object-id> --tags --all-tags
 Goal: list objects in a view and see decoded `auto:filename_b64` / `auto:relpath_b64` tags.
 
 ```bash
-lfs stats view-objects "All" --all-tags
+lfs info view-objects "All" --all-tags
 ```
 
 Goal: show encoded + decoded values (debugging).
 
 ```bash
-lfs stats view-objects "All" --all-tags --raw-tags
+lfs info view-objects "All" --all-tags --raw-tags
 ```
 
 ## Get an object checksum
@@ -142,13 +142,13 @@ LatticeFS way: ask the CLI for the object checksum directly.
 Goal: get the content hash for the current version.
 
 ```bash
-lfs stats checksum <object-id>
+lfs info checksum <object-id>
 ```
 
 Goal: get the checksum for a specific version.
 
 ```bash
-lfs stats checksum <object-id>@v2
+lfs info checksum <object-id>@v2
 ```
 
 ## See object versions

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -137,9 +137,9 @@ Example output:
 Verified <object-id>
 ```
 
-## Stats commands
+## Info commands
 
-### `lfs stats checksum <ref>`
+### `lfs info checksum <ref>`
 Show the content checksum for an object (BLAKE3 merkle root).
 
 Arguments:
@@ -147,7 +147,7 @@ Arguments:
 
 Example:
 ```bash
-lfs stats checksum <object-id>
+lfs info checksum <object-id>
 ```
 
 Example output:
@@ -161,7 +161,7 @@ Size bytes: 12345
 Chunks: 12
 ```
 
-### `lfs stats object <ref> [--all-versions]`
+### `lfs info object <ref> [--all-versions]`
 Show summary statistics for a single object.
 
 Arguments:
@@ -170,19 +170,19 @@ Arguments:
 
 Example:
 ```bash
-lfs stats object <object-id> --all-versions
+lfs info object <object-id> --all-versions
 ```
 
-### `lfs stats view <name|id>`
+### `lfs info view <name|id>`
 Show statistics for a built-in or dynamic view. Built-in view names can be provided in English or German.
 
 Examples:
 ```bash
-lfs stats view recent
-lfs stats view neueste  # German equivalent
+lfs info view recent
+lfs info view neueste  # German equivalent
 ```
 
-### `lfs stats view-objects <name|id> [--all-tags] [--raw-tags]`
+### `lfs info view-objects <name|id> [--all-tags] [--raw-tags]`
 List objects for a view with minimal tag output.
 
 Notes:
@@ -192,17 +192,17 @@ Notes:
 
 Example:
 ```bash
-lfs stats view-objects recent --all-tags
+lfs info view-objects recent --all-tags
 # or in German:
-lfs stats view-objects neueste --all-tags
+lfs info view-objects neueste --all-tags
 ```
 
-### `lfs stats views`
+### `lfs info views`
 Summarize all built-in and dynamic views. Built-in views are displayed in the system locale (English or German).
 
 Example:
 ```bash
-lfs stats views
+lfs info views
 ```
 
 Example output (German locale):
@@ -216,28 +216,28 @@ Built-in views:
 - Alle Objekte: 15 objects
 ```
 
-### `lfs stats policy <name>`
+### `lfs info policy <name>`
 Show policy details and how many objects reference it.
 
 Example:
 ```bash
-lfs stats policy compliance
+lfs info policy compliance
 ```
 
-### `lfs stats policies`
+### `lfs info policies`
 Summarize policy counts and list names.
 
 Example:
 ```bash
-lfs stats policies
+lfs info policies
 ```
 
-### `lfs stats shares`
+### `lfs info shares`
 Summarize shared capabilities (total, active/expired, permissions).
 
 Example:
 ```bash
-lfs stats shares
+lfs info shares
 ```
 
 ## Object management
@@ -598,7 +598,7 @@ Dynamic views:
 
 Notes:
 - Dynamic view IDs are UUIDs and can be used anywhere a view name is accepted.
-- Built-in view names can be referenced in either English or German (e.g., `lfs stats view recent` or `lfs stats view neueste`).
+- Built-in view names can be referenced in either English or German (e.g., `lfs info view recent` or `lfs info view neueste`).
 
 ### `lfs view delete <name|id>`
 Delete a dynamic view.

--- a/docs/i18n-localization.md
+++ b/docs/i18n-localization.md
@@ -99,7 +99,7 @@ assert_eq!(BuiltinView::by_name("projekte"), Some(BuiltinView::Projects));
 1. **base/Cargo.toml**: Added `sys-locale = "0.3"` dependency
 2. **base/src/views/builtin.rs**: Added `Locale` enum and localized methods
 3. **base/src/views/mod.rs**: Exported `Locale` type
-4. **cli/src/commands/stats.rs**: Updated to use localized names
+4. **cli/src/commands/info.rs**: Updated to use localized names
 5. **cli/src/commands/view.rs**: Updated to use localized names
 6. **gui/src-tauri/src/commands.rs**: Updated to use localized names
 

--- a/docs/object-listing.md
+++ b/docs/object-listing.md
@@ -3,32 +3,32 @@
 This document explains how to list objects in LatticeFS, including “all objects” and filtered subsets (per‑tag, per‑state, etc.).
 
 ## Is there a direct "list objects" command?
-There is **no dedicated `lfs objects list` command** in the CLI. However, you can list objects in a view directly using the **`lfs stats view-objects`** command (see [CLI Reference](cli.md#lfs-stats-view-objects-nameid---all-tags---raw-tags) for details).
+There is **no dedicated `lfs objects list` command** in the CLI. However, you can list objects in a view directly using the **`lfs info view-objects`** command (see [CLI Reference](cli.md#lfs-info-view-objects-nameid---all-tags---raw-tags) for details).
 
 For more extensive operations, listing is done through **views** and **exports**, which are backed by Lattice Query Language (LQL).
 
 In practice, you can list objects by:
-- using `lfs stats view-objects <view-name|view-id>` to print object IDs and tags directly to stdout,
+- using `lfs info view-objects <view-name|view-id>` to print object IDs and tags directly to stdout,
 - exporting a view to a directory (filenames are object IDs), or
 - browsing a view via the read‑only FUSE mount.
 
 This keeps listing consistent with the query system, and avoids adding a separate listing path that would bypass query semantics.
 
-## Direct listing with stats view-objects
-To quickly list objects in a view without exporting, use `lfs stats view-objects`:
+## Direct listing with info view-objects
+To quickly list objects in a view without exporting, use `lfs info view-objects`:
 
 ```bash
-lfs stats view-objects "All"
+lfs info view-objects "All"
 ```
 
 This prints each object ID to stdout, one per line.
 
 To include all tags (including system/auto tags):
 ```bash
-lfs stats view-objects "All" --all-tags
+lfs info view-objects "All" --all-tags
 ```
 
-For full details and options, see the [CLI Reference](cli.md#lfs-stats-view-objects-nameid---all-tags---raw-tags).
+For full details and options, see the [CLI Reference](cli.md#lfs-info-view-objects-nameid---all-tags---raw-tags).
 
 ## List all objects
 Use the built‑in `All` view and export it.

--- a/docs/views.md
+++ b/docs/views.md
@@ -15,7 +15,7 @@ LatticeFS includes several built-in views that are always available:
 | Approved | `state:approved SORT updated DESC` | Approved objects |
 | All | `trust >= 0` | All objects in the repository |
 
-**Localization**: Built-in view names and descriptions are automatically displayed in your system's locale. English and German are currently supported, with German as the default for non-English locales. Both English and German names work in CLI commands (e.g., `lfs stats view recent` or `lfs stats view neueste`). See [Localization](i18n-localization.md) for details.
+**Localization**: Built-in view names and descriptions are automatically displayed in your system's locale. English and German are currently supported, with German as the default for non-English locales. Both English and German names work in CLI commands (e.g., `lfs info view recent` or `lfs info view neueste`). See [Localization](i18n-localization.md) for details.
 
 ## What you can do with views
 - Create a view from an LQL query


### PR DESCRIPTION
### Motivation
- The CLI subcommand name `stats` is being replaced with `info` to better reflect the command semantics.
- All user-facing references (help, docs, recipes) need to stay consistent with the new name.
- Tests must be updated to exercise the renamed command so CI matches local behavior.

### Description
- Renamed the implementation file and public types: `cli/src/commands/stats.rs` → `cli/src/commands/info.rs` and converted `Stats*` symbols to `Info*` (e.g., `StatsCommand` → `InfoCommand`).
- Updated CLI wiring: replaced the `Stats` enum variant and dispatcher with `Info` in `cli/src/commands/mod.rs` and `cli/src/main.rs`, and it now calls `commands::info::run`.
- Updated documentation and recipes to reference `lfs info` instead of `lfs stats` in `docs/cli.md`, `docs/cli-recipes.md`, `docs/object-listing.md`, `docs/views.md`, and `docs/i18n-localization.md`.
- Adjusted integration tests in `cli/tests/cli_flow.rs` to use `info` for the view-related assertions.

### Testing
- Ran the test suite with `cargo test`, which started compilation but ultimately failed due to a missing system dependency (`glib-2.0`) required by `glib-sys`, so tests did not fully complete.
- Updated code and docs were compiled as part of the test run up to the system dependency failure (no functional test failures attributable to the rename were observed before the external dependency error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698632b6257c8321a3fc92eede558f3b)