### PR TITLE
Add object context menu actions (rename/versions/editor/views) and `lfs rename` CLI

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod link;
 pub mod meta;
 pub mod mount;
 pub mod policy;
+pub mod rename;
 pub mod revise;
 pub mod revoke;
 pub mod share;
@@ -35,6 +36,7 @@ pub enum Command {
     Tag(tag::TagArgs),
     Tags(tags::TagsArgs),
     Untag(untag::UntagArgs),
+    Rename(rename::RenameArgs),
     Link(link::LinkArgs),
     Meta(meta::MetaArgs),
     Get(get::GetArgs),

--- a/cli/src/commands/rename.rs
+++ b/cli/src/commands/rename.rs
@@ -1,0 +1,77 @@
+use anyhow::{Context, Result};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use clap::Args;
+use latticefs_base::LatticeRepo;
+use latticefs_base::model::Tag;
+
+use super::common::{ensure_identity, identity_actor, resolve_object_id};
+
+#[derive(Args, Debug)]
+pub struct RenameArgs {
+    /// Object reference
+    pub reference: String,
+    /// New filename to store as auto:filename_b64
+    pub name: String,
+}
+
+pub async fn run(repo: LatticeRepo, args: RenameArgs) -> Result<()> {
+    let name = args.name.trim();
+    if name.is_empty() {
+        anyhow::bail!("Filename cannot be empty");
+    }
+
+    let object_id = resolve_object_id(&repo, &args.reference)?;
+    let actor = match ensure_identity("default", None) {
+        Ok(id) => identity_actor(&id),
+        Err(_) => [0u8; 32],
+    };
+
+    let mut object = repo
+        .metadata
+        .load_object(&object_id)
+        .with_context(|| format!("Object not found: {}", object_id))?;
+    repo.authorize_object_permission(&object, latticefs_base::Permission::Write, false)?;
+    repo.enforce_rate_limit(1)?;
+
+    let removed: Vec<_> = object
+        .tags
+        .iter()
+        .filter(|t| t.key == "auto:filename_b64")
+        .cloned()
+        .collect();
+
+    if !removed.is_empty() {
+        object.remove_tag("auto:filename_b64");
+        for tag in removed {
+            repo.metadata
+                .remove_from_tag_index(&tag.full_path(), object_id.as_bytes())?;
+        }
+    }
+
+    let encoded = encode_filename_tag(name);
+    let tag = Tag::new("auto:filename_b64".to_string(), encoded, actor);
+    let full = tag.full_path();
+    object.add_tag(tag);
+    repo.metadata
+        .add_to_tag_index(&full, object_id.as_bytes())?;
+    repo.metadata.store_object(&object)?;
+
+    println!("Renamed {} to {}", object_id, name);
+    Ok(())
+}
+
+fn encode_filename_tag(name: &str) -> String {
+    URL_SAFE_NO_PAD.encode(name.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_filename_tag;
+
+    #[test]
+    fn encode_filename_tag_uses_base64url() {
+        let encoded = encode_filename_tag("Report Final (v1).txt");
+        assert_eq!(encoded, "UmVwb3J0IEZpbmFsICh2MSkudHh0");
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -67,6 +67,10 @@ async fn main() -> Result<()> {
             let repo = commands::common::open_repo(cli.repo.clone())?;
             commands::untag::run(repo, args).await?;
         }
+        commands::Command::Rename(args) => {
+            let repo = commands::common::open_repo(cli.repo.clone())?;
+            commands::rename::run(repo, args).await?;
+        }
         commands::Command::Link(args) => {
             let repo = commands::common::open_repo(cli.repo.clone())?;
             commands::link::run(repo, args).await?;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -321,6 +321,19 @@ Example output:
 Untagged <object-id>
 ```
 
+### `lfs rename <ref> <name>`
+Update the `auto:filename_b64` tag for an object (used as the display name in the GUI).
+
+Example:
+```bash
+lfs rename <object-id> "Report Final (v1).txt"
+```
+
+Example output:
+```text
+Renamed <object-id> to Report Final (v1).txt
+```
+
 ### `lfs link <object-a> <link-type> <object-b>`
 Create a typed link between objects.
 

--- a/gui/src/components/nexus/ContentArea.tsx
+++ b/gui/src/components/nexus/ContentArea.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { ObjectInfo } from "@/lib/lfs";
+import type { ObjectInfo, ViewInfo } from "@/lib/lfs";
 import { FolderOpen, Loader2 } from "lucide-react";
 import { GraphView } from "./GraphView";
 import { GridView } from "./GridView";
@@ -20,6 +20,11 @@ interface ContentAreaProps {
   onRemoveTag: (object: ObjectInfo, tag: TagInfo) => void;
   onSetTrust: (object: ObjectInfo, trust: number | null) => void;
   onShowDetails: (object: ObjectInfo) => void;
+  onOpenVersions: (object: ObjectInfo) => void;
+  onOpenEditor: (object: ObjectInfo) => void;
+  onRenameObject: (object: ObjectInfo) => void;
+  views: ViewInfo[];
+  onViewSelect: (viewId: string) => void;
   sort: SortState;
   onSortChange: (next: SortState) => void;
   filters: FilterState;
@@ -39,6 +44,11 @@ export const ContentArea = ({
   onRemoveTag,
   onSetTrust,
   onShowDetails,
+  onOpenVersions,
+  onOpenEditor,
+  onRenameObject,
+  views,
+  onViewSelect,
   sort,
   onSortChange,
   filters,
@@ -179,6 +189,11 @@ export const ContentArea = ({
     onRemoveTag,
     onSetTrust,
     onShowDetails,
+    onOpenVersions,
+    onOpenEditor,
+    onRenameObject,
+    views,
+    onViewSelect,
   };
 
   return (

--- a/gui/src/components/nexus/GraphView.tsx
+++ b/gui/src/components/nexus/GraphView.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { ObjectNode } from "./ObjectNode";
-import type { ObjectInfo, TagInfo } from "@/lib/lfs";
+import type { ObjectInfo, TagInfo, ViewInfo } from "@/lib/lfs";
 import { ObjectContextMenu } from "./ObjectContextMenu";
 import { GraphLegend } from "./GraphLegend";
 import {
@@ -22,6 +22,11 @@ interface GraphViewProps {
   onRemoveTag: (object: ObjectInfo, tag: TagInfo) => void;
   onSetTrust: (object: ObjectInfo, trust: number | null) => void;
   onShowDetails: (object: ObjectInfo) => void;
+  onOpenVersions: (object: ObjectInfo) => void;
+  onOpenEditor: (object: ObjectInfo) => void;
+  onRenameObject: (object: ObjectInfo) => void;
+  views: ViewInfo[];
+  onViewSelect: (viewId: string) => void;
 }
 
 // Graph container dimensions
@@ -41,6 +46,11 @@ export const GraphView = ({
   onRemoveTag,
   onSetTrust,
   onShowDetails,
+  onOpenVersions,
+  onOpenEditor,
+  onRenameObject,
+  views,
+  onViewSelect,
 }: GraphViewProps) => {
   const [hoveredObject, setHoveredObject] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -236,8 +246,13 @@ export const GraphView = ({
             <ObjectContextMenu
               key={obj.id}
               object={obj}
+              views={views}
+              onViewSelect={onViewSelect}
               onOpen={onObjectOpen}
               onShowDetails={onShowDetails}
+              onOpenVersions={onOpenVersions}
+              onOpenEditor={onOpenEditor}
+              onRename={onRenameObject}
               onRequestAddTag={onRequestAddTag}
               onRemoveTag={onRemoveTag}
               onSetTrust={onSetTrust}

--- a/gui/src/components/nexus/GridView.tsx
+++ b/gui/src/components/nexus/GridView.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ObjectCard } from "./ObjectCard";
 import { ObjectContextMenu } from "./ObjectContextMenu";
-import type { ObjectInfo, TagInfo } from "@/lib/lfs";
+import type { ObjectInfo, TagInfo, ViewInfo } from "@/lib/lfs";
 
 interface GridViewProps {
   objects: ObjectInfo[];
@@ -14,6 +14,11 @@ interface GridViewProps {
   onRemoveTag: (object: ObjectInfo, tag: TagInfo) => void;
   onSetTrust: (object: ObjectInfo, trust: number | null) => void;
   onShowDetails: (object: ObjectInfo) => void;
+  onOpenVersions: (object: ObjectInfo) => void;
+  onOpenEditor: (object: ObjectInfo) => void;
+  onRenameObject: (object: ObjectInfo) => void;
+  views: ViewInfo[];
+  onViewSelect: (viewId: string) => void;
 }
 
 export const GridView = ({
@@ -26,6 +31,11 @@ export const GridView = ({
   onRemoveTag,
   onSetTrust,
   onShowDetails,
+  onOpenVersions,
+  onOpenEditor,
+  onRenameObject,
+  views,
+  onViewSelect,
 }: GridViewProps) => {
   const handleClick = useCallback(
     (obj: ObjectInfo, e: React.MouseEvent) => {
@@ -60,8 +70,13 @@ export const GridView = ({
             <ObjectContextMenu
               key={obj.id}
               object={obj}
+              views={views}
+              onViewSelect={onViewSelect}
               onOpen={onObjectOpen}
               onShowDetails={onShowDetails}
+              onOpenVersions={onOpenVersions}
+              onOpenEditor={onOpenEditor}
+              onRename={onRenameObject}
               onRequestAddTag={onRequestAddTag}
               onRemoveTag={onRemoveTag}
               onSetTrust={onSetTrust}

--- a/gui/src/components/nexus/ListView.tsx
+++ b/gui/src/components/nexus/ListView.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ObjectRow } from "./ObjectRow";
 import { ArrowUp, ArrowDown } from "lucide-react";
-import type { ObjectInfo, TagInfo } from "@/lib/lfs";
+import type { ObjectInfo, TagInfo, ViewInfo } from "@/lib/lfs";
 import { ObjectContextMenu } from "./ObjectContextMenu";
 import type { SortState, SortField } from "./NexusLayout";
 
@@ -17,6 +17,11 @@ interface ListViewProps {
   onRemoveTag: (object: ObjectInfo, tag: TagInfo) => void;
   onSetTrust: (object: ObjectInfo, trust: number | null) => void;
   onShowDetails: (object: ObjectInfo) => void;
+  onOpenVersions: (object: ObjectInfo) => void;
+  onOpenEditor: (object: ObjectInfo) => void;
+  onRenameObject: (object: ObjectInfo) => void;
+  views: ViewInfo[];
+  onViewSelect: (viewId: string) => void;
   sort: SortState;
   onSortChange: (next: SortState) => void;
 }
@@ -31,6 +36,11 @@ export const ListView = ({
   onRemoveTag,
   onSetTrust,
   onShowDetails,
+  onOpenVersions,
+  onOpenEditor,
+  onRenameObject,
+  views,
+  onViewSelect,
   sort,
   onSortChange,
 }: ListViewProps) => {
@@ -130,8 +140,13 @@ export const ListView = ({
             <ObjectContextMenu
               key={obj.id}
               object={obj}
+              views={views}
+              onViewSelect={onViewSelect}
               onOpen={onObjectOpen}
               onShowDetails={onShowDetails}
+              onOpenVersions={onOpenVersions}
+              onOpenEditor={onOpenEditor}
+              onRename={onRenameObject}
               onRequestAddTag={onRequestAddTag}
               onRemoveTag={onRemoveTag}
               onSetTrust={onSetTrust}

--- a/gui/src/components/nexus/NexusLayout.tsx
+++ b/gui/src/components/nexus/NexusLayout.tsx
@@ -7,12 +7,14 @@ import { StatusBar } from "./StatusBar";
 import type { ObjectInfo, TagInfo, VersionInfo } from "@/lib/lfs";
 import { addObjectTag, removeObjectTag, setObjectTrustLevel, openObject, isTextEditable } from "@/lib/lfs";
 import { useViewObjects } from "@/hooks/useViewObjects";
+import { useViews } from "@/hooks/useViews";
 import { toast } from "sonner";
 import { ObjectDetailPanel } from "./ObjectDetailPanel";
 import { NexusSettingsDialog } from "./NexusSettingsDialog";
 import { VersionHistoryDialog } from "./VersionHistoryDialog";
 import { VersionDiffDialog } from "./VersionDiffDialog";
 import { TextEditorDialog } from "./TextEditorDialog";
+import { ObjectRenameDialog } from "./ObjectRenameDialog";
 
 export type ViewMode = "graph" | "grid" | "list";
 export type SortField =
@@ -69,7 +71,9 @@ export const NexusLayout = ({ currentViewId, onViewChange }: NexusLayoutProps) =
   const [diffObject, setDiffObject] = useState<ObjectInfo | null>(null);
   const [diffVersionA, setDiffVersionA] = useState<VersionInfo | null>(null);
   const [diffVersionB, setDiffVersionB] = useState<VersionInfo | null>(null);
+  const [renameObject, setRenameObject] = useState<ObjectInfo | null>(null);
 
+  const { data: views = [] } = useViews();
   const { data, isLoading, error } = useViewObjects(currentViewId || "recent");
   const [objects, setObjects] = useState<ObjectInfo[]>([]);
 
@@ -220,6 +224,63 @@ export const NexusLayout = ({ currentViewId, onViewChange }: NexusLayoutProps) =
     setDetailPanelOpen(true);
   }, []);
 
+  const handleRequestRename = useCallback((object: ObjectInfo) => {
+    setActiveObjectId(object.id);
+    setSelectedObjects([object.id]);
+    setRenameObject(object);
+  }, []);
+
+  const encodeBase64Url = (value: string) => {
+    const bytes = new TextEncoder().encode(value);
+    let binary = "";
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary)
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  };
+
+  const handleRenameObject = useCallback(
+    async (object: ObjectInfo, name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) {
+        toast.error("Der Name darf nicht leer sein.");
+        return;
+      }
+
+      const encoded = encodeBase64Url(trimmed);
+      const previous = object.tags.find((tag) => tag.key === "auto:filename_b64");
+      const nextTag: TagInfo = { key: "auto:filename_b64", value: encoded };
+
+      try {
+        if (previous) {
+          await removeObjectTag(object.id, previous);
+        }
+        const updated = await addObjectTag(object.id, nextTag);
+        setObjects((prev) =>
+          prev.map((obj) => {
+            if (obj.id !== object.id) return obj;
+            if (updated) return { ...obj, ...updated, views: obj.views };
+            const filtered = obj.tags.filter(
+              (tag) => !(tag.key === "auto:filename_b64" && tag.value === previous?.value)
+            );
+            const exists = filtered.some(
+              (tag) => tag.key === nextTag.key && tag.value === nextTag.value
+            );
+            return { ...obj, name: trimmed, tags: exists ? filtered : [...filtered, nextTag] };
+          })
+        );
+        toast.success("Dateiname aktualisiert");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Dateiname konnte nicht aktualisiert werden");
+        throw err;
+      }
+    },
+    []
+  );
+
   const handleOpenVersions = useCallback((object: ObjectInfo) => {
     setVersionHistoryObject(object);
   }, []);
@@ -309,6 +370,11 @@ export const NexusLayout = ({ currentViewId, onViewChange }: NexusLayoutProps) =
               onRemoveTag={handleRemoveTag}
               onSetTrust={handleSetTrust}
               onShowDetails={handleShowDetails}
+              onOpenVersions={handleOpenVersions}
+              onOpenEditor={handleOpenEditor}
+              onRenameObject={handleRequestRename}
+              views={views}
+              onViewSelect={onViewChange}
               sort={sort}
               onSortChange={setSort}
               filters={filters}
@@ -383,6 +449,15 @@ export const NexusLayout = ({ currentViewId, onViewChange }: NexusLayoutProps) =
           onOpenChange={(open) => { if (!open) setEditorObject(null); }}
           object={editorObject}
           onObjectUpdated={handleEditorObjectUpdated}
+        />
+      )}
+
+      {renameObject && (
+        <ObjectRenameDialog
+          open={!!renameObject}
+          onOpenChange={(open) => { if (!open) setRenameObject(null); }}
+          object={renameObject}
+          onRename={handleRenameObject}
         />
       )}
     </div>

--- a/gui/src/components/nexus/ObjectContextMenu.tsx
+++ b/gui/src/components/nexus/ObjectContextMenu.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { ObjectInfo, TagInfo } from "@/lib/lfs";
+import type { ObjectInfo, TagInfo, ViewInfo } from "@/lib/lfs";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -11,12 +11,27 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { BadgePlus, FolderOpen, Shield, Tag, Trash2 } from "lucide-react";
+import { isTextEditable } from "@/lib/lfs";
+import {
+  BadgePlus,
+  FileEdit,
+  FolderOpen,
+  History,
+  Pencil,
+  Shield,
+  Tag,
+  Trash2,
+} from "lucide-react";
 
 interface ObjectContextMenuProps {
   object: ObjectInfo;
+  views?: ViewInfo[];
+  onViewSelect?: (viewId: string) => void;
   onOpen: (object: ObjectInfo) => void;
   onShowDetails: (object: ObjectInfo) => void;
+  onOpenVersions?: (object: ObjectInfo) => void;
+  onOpenEditor?: (object: ObjectInfo) => void;
+  onRename?: (object: ObjectInfo) => void;
   onRequestAddTag: (object: ObjectInfo) => void;
   onRemoveTag: (object: ObjectInfo, tag: TagInfo) => void;
   onSetTrust: (object: ObjectInfo, trust: number | null) => void;
@@ -34,13 +49,24 @@ const trustOptions = [
 
 export const ObjectContextMenu = ({
   object,
+  views,
+  onViewSelect,
   onOpen,
   onShowDetails,
+  onOpenVersions,
+  onOpenEditor,
+  onRename,
   onRequestAddTag,
   onRemoveTag,
   onSetTrust,
   children,
 }: ObjectContextMenuProps) => {
+  const viewOptions = (views ?? [])
+    .filter((view) => object.views.includes(view.id))
+    .sort((a, b) => a.name.localeCompare(b.name, "de", { sensitivity: "base" }));
+  const canEdit = isTextEditable(object.extension) && !object.isSealed;
+  const canOpenViews = viewOptions.length > 0 && !!onViewSelect;
+
   return (
     <ContextMenu>
       <ContextMenuTrigger>
@@ -53,10 +79,45 @@ export const ObjectContextMenu = ({
           <FolderOpen className="w-4 h-4 mr-2" />
           Öffnen
         </ContextMenuItem>
+        {canEdit && onOpenEditor && (
+          <ContextMenuItem onSelect={() => onOpenEditor(object)}>
+            <FileEdit className="w-4 h-4 mr-2" />
+            Im Editor öffnen
+          </ContextMenuItem>
+        )}
         <ContextMenuItem onSelect={() => onShowDetails(object)}>
           <Shield className="w-4 h-4 mr-2" />
           Details anzeigen
         </ContextMenuItem>
+        {onRename && (
+          <ContextMenuItem onSelect={() => onRename(object)}>
+            <Pencil className="w-4 h-4 mr-2" />
+            Umbenennen
+          </ContextMenuItem>
+        )}
+        {onOpenVersions && (
+          <ContextMenuItem onSelect={() => onOpenVersions(object)}>
+            <History className="w-4 h-4 mr-2" />
+            Versionen prüfen
+          </ContextMenuItem>
+        )}
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>
+            <FolderOpen className="w-4 h-4 mr-2" />
+            Perspektiven
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent className="w-56">
+            {!canOpenViews ? (
+              <ContextMenuItem disabled>Keine Perspektiven verfügbar</ContextMenuItem>
+            ) : (
+              viewOptions.map((view) => (
+                <ContextMenuItem key={view.id} onSelect={() => onViewSelect?.(view.id)}>
+                  {view.name}
+                </ContextMenuItem>
+              ))
+            )}
+          </ContextMenuSubContent>
+        </ContextMenuSub>
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => onRequestAddTag(object)}>
           <BadgePlus className="w-4 h-4 mr-2" />

--- a/gui/src/components/nexus/ObjectRenameDialog.tsx
+++ b/gui/src/components/nexus/ObjectRenameDialog.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import type { ObjectInfo } from "@/lib/lfs";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2 } from "lucide-react";
+
+interface ObjectRenameDialogProps {
+  object: ObjectInfo | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRename: (object: ObjectInfo, name: string) => Promise<void>;
+}
+
+export const ObjectRenameDialog = ({
+  object,
+  open,
+  onOpenChange,
+  onRename,
+}: ObjectRenameDialogProps) => {
+  const [name, setName] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!object || !open) return;
+    setName(object.name);
+    setError(null);
+  }, [object, open]);
+
+  if (!object) return null;
+
+  const handleSave = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Ein Name ist erforderlich.");
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      await onRename(object, trimmed);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Umbenennen fehlgeschlagen.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !isSaving && onOpenChange(next)}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Objekt umbenennen</DialogTitle>
+          <DialogDescription>
+            Der Anzeigename wird als auto:filename_b64-Tag gespeichert.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 py-3">
+          <Label htmlFor="rename-object-name">Neuer Name</Label>
+          <Input
+            id="rename-object-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            disabled={isSaving}
+          />
+          {error && (
+            <div className="text-sm text-destructive bg-destructive/10 px-3 py-2 rounded-md">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
+            Abbrechen
+          </Button>
+          <Button onClick={handleSave} disabled={isSaving || !name.trim()}>
+            {isSaving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            Umbenennen
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/gui/src/lib/lfs.mock.ts
+++ b/gui/src/lib/lfs.mock.ts
@@ -20,6 +20,11 @@ import type {
 } from "./lfs";
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const decodeBase64Url = (value: string) => {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  return atob(padded);
+};
 
 // Event handlers for simulated progress
 let progressHandlers: ((p: ImportProgress) => void)[] = [];
@@ -395,6 +400,13 @@ export const mockAddObjectTag = async (
   );
   if (!exists) {
     object.tags.push(tag);
+  }
+  if (tag.key === "auto:filename_b64") {
+    try {
+      object.name = decodeBase64Url(tag.value);
+    } catch {
+      // ignore decode errors in mock
+    }
   }
   return object;
 };


### PR DESCRIPTION
### Motivation
- Provide a rich right‑click context menu for objects in the graph/grid/list views so users can quickly rename, open in editor, inspect versions, and jump to perspectives. 
- Ensure renaming is backed by the existing `auto:filename_b64` tag and expose this capability in the CLI for scripts and headless workflows.

### Description
- Expanded the object context menu to include `Umbenennen` (rename), `Versionen prüfen` (open versions), `Im Editor öffnen` (open in editor) and a Perspectives sub‑menu, and wired those actions into the UI handlers (updates to `ObjectContextMenu.tsx`, and view components). 
- Added a modal rename dialog `ObjectRenameDialog.tsx` and integrated rename flows into the main layout so renaming updates the `auto:filename_b64` tag and the in‑memory object list (`NexusLayout.tsx`, `ContentArea.tsx`, `GraphView.tsx`, `GridView.tsx`, `ListView.tsx`).
- Added a new CLI command `lfs rename <ref> <name>` which encodes the filename as base64url and stores it as `auto:filename_b64` (new file `cli/src/commands/rename.rs`, and registration in `cli/src/commands/mod.rs` and `cli/src/main.rs`).
- Updated browser mocks to decode the `auto:filename_b64` tag for local development and to reflect name updates (`gui/src/lib/lfs.mock.ts`).
- Added CLI docs for the new `lfs rename` command in `docs/cli.md` and included a unit test for the base64url encoding in the CLI command.

### Testing
- Ran `cargo test -p cli`, which executed the CLI unit tests (including the `encode_filename_tag` test) and completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986339e5c8483218ededd88670c979d)